### PR TITLE
DAT-339 from https://github.com/GreaterLondonAuthority/Data_…

### DIFF
--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -302,6 +302,10 @@ class DataPressHarvester(HarvesterBase):
                 format = resource["format"]
                 resource["url"] = f"{base}/{dataset}/{id}/{file}.{format}"
 
+        # We remove the "state" key so that the current state (ie active/deleted) is
+        # used instead of the state in the source. This is to prevent deleted datasets
+        # being marked as active.
+        del package_dict["state"]
         return package_dict
 
     def import_stage(self, harvest_object):


### PR DESCRIPTION
…don/pull/45

Created from https://github.com/GreaterLondonAuthority/Data_for_London/pull/45 by running

```
git format-patch --relative=src/ckanext-datapress_harvester origin/develop --stdout > dat-339.mbox
```

in the main repository and then applying the patch to this repository with

```
git am ../../../Data_for_London-alt/dat-339.mbox
```