### PR TITLE
DAT-405 - Harvester extra fields

### DIFF
--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -289,7 +289,7 @@ class DataPressHarvester(HarvesterBase):
     def _resource_format_from_url(self, url):
         try:
             p = urllib.parse.urlparse(url).path
-            return os.path.splitext(p)[1][1:]
+            return os.path.splitext(p)[1][1:] or "data"
         except Exception as e:
             return "data"
 
@@ -373,8 +373,6 @@ class DataPressHarvester(HarvesterBase):
 
             if "format" not in resource or not resource["format"]:
                 resource["format"] = self._resource_format_from_url(resource["url"])
-
-            log.info(f"Resource url: {resource['url']}, format: {resource['format']}")
 
         # We remove the "state" key so that the current state (ie active/deleted) is
         # used instead of the state in the source. This is to prevent deleted datasets

--- a/ckanext/datapress_harvester/util/__init__.py
+++ b/ckanext/datapress_harvester/util/__init__.py
@@ -52,3 +52,43 @@ def sanitise(s):
     no_duplicate_spaces = re.sub("\s{2,}", " ", without_non_alpha)
     no_spaces = no_duplicate_spaces.replace(" ", "-")
     return no_spaces.lower()
+
+
+# Helper functions for getting and setting values in package["extras"].
+# package["extras"] is a list of dictionaries of the form:
+# [ {"key": <key>, "value": <value>}, {"key": <key>, "value": <value>}, ...]
+def remove_extras(extras, keys):
+    """
+    Return a new dictionary of extras with the specified keys removed.
+    """
+    new_extras = []
+    for e in extras:
+        if e["key"] not in keys:
+            new_extras.append({"key": e["key"], "value": e["value"]})
+    return new_extras
+
+
+def get_package_extra_val(extras, key):
+    """
+    Return a value from package extras, given the key.
+    Return None if the key does not exist.
+    """
+    for extra in extras:
+        if extra["key"] == key:
+            return extra["value"]
+    return None
+
+
+def upsert_package_extra(extras, key, val):
+    """
+    Update the value for <key> in package['extras'] if it exists.
+    Insert it if not.
+    Returns the updated package['extras'].
+    """
+    for extra in extras:
+        if extra["key"] == key:
+            extra["value"] = val
+            return extras
+
+    extras.append({"key": key, "value": val})
+    return extras


### PR DESCRIPTION
# Harvester extra fields
This PR addresses:
- [DAT-405](https://london.atlassian.net/browse/DAT-405): ensures that extra fields we add to the CKAN `package['extras']` are preserved when we re-run the DataPress harvester. In the import stage of the DataPress we now check whether the package we're about to import already exists, and if so we copy across any package extras (apart from last modified times etc.) from the existing package to the freshly-harvested one.
- [DAT-404](https://london.atlassian.net/browse/DAT-404): fixes missing resource icons for datasets harvested from Brent & Barnet

# Changes
- Added code to the `import_stage` of the harvester to check for an existing package by ID, and copy across any relevant extras.
- Moved some extras-related helper functions into `datapress_harvester.util`
- Added code to `_datapress_to_ckan` to check whether resources have a `format` key. If not, the `format` is created by parsing the resource `url` and extracting the extension from any filename in the URL. A default of `data` is returned if no extension is found.

