### PR TITLE
DAT-409 - Add Socrata harvester

### DIFF
--- a/ckanext/datapress_harvester/harvesters/__init__.py
+++ b/ckanext/datapress_harvester/harvesters/__init__.py
@@ -1,3 +1,4 @@
 from ckanext.datapress_harvester.harvesters.datapress import DataPressHarvester
 from ckanext.datapress_harvester.harvesters.nomis_localauthprofile import NomisLocalAuthorityProfileScraper
 from ckanext.datapress_harvester.harvesters.redbridge import RedbridgeHarvester
+from ckanext.datapress_harvester.harvesters.soda import SODAHarvester

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -15,6 +15,7 @@ from ckanext.datapress_harvester.util import (
     upsert_package_extra,
     get_package_extra_val,
     get_harvested_dataset_ids,
+    add_default_keys,
     add_default_extras,
     add_existing_extras,
 )
@@ -193,7 +194,7 @@ class RedbridgeHarvester(HarvesterBase):
 
         try:
             package_dict = json.loads(harvest_object.content)
-            if package_dict["action"] == "delete":
+            if package_dict.get("action", None) == "delete":
                 log.info(f"Deleting dataset with ID: {package_dict['id']}")
                 result = toolkit.get_action("dataset_purge")(
                     base_context.copy(), package_dict
@@ -205,14 +206,13 @@ class RedbridgeHarvester(HarvesterBase):
             )
 
         try:
-            # Merge our scraped package dict into any existing package dict
-            # The keys in the dict returned by _dataset_to_pkgdict will override those in existing_dataset
-
             # Set the owner org of the new dataset to the org set in the harvest source
             harvest_source = toolkit.get_action("package_show")(
                 base_context.copy(), {"id": harvest_object.source.id}
             )
             package_dict["owner_org"] = harvest_source.get("owner_org")
+
+            add_default_keys(package_dict)
 
             add_existing_extras(package_dict, base_context.copy())
 

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -214,20 +214,6 @@ class RedbridgeHarvester(HarvesterBase):
             )
             package_dict["owner_org"] = harvest_source.get("owner_org")
 
-            # Set some default keys so CKAN does not report them as being changed later.
-            default_keys = [
-                "author",
-                "author_email",
-                "url",
-                "version",
-            ]
-            for key in default_keys:
-                if key not in package_dict:
-                    package_dict[key] = ""
-
-            if "extras" not in package_dict:
-                package_dict["extras"] = []
-
             add_existing_extras(package_dict, base_context.copy())
 
             add_default_extras(package_dict)

--- a/ckanext/datapress_harvester/harvesters/soda.py
+++ b/ckanext/datapress_harvester/harvesters/soda.py
@@ -16,6 +16,7 @@ from ckanext.datapress_harvester.util import (
     upsert_package_extra,
     sanitise,
     get_harvested_dataset_ids,
+    add_default_keys,
     add_default_extras,
     add_existing_extras
 )
@@ -270,7 +271,7 @@ class SODAHarvester(HarvesterBase):
             case "delete":
                 try:
                     ok = self._delete_dataset(base_context.copy(), imported_dataset)
-                    log.info("Successfullt deleted")
+                    log.info("Successfully deleted")
                     return ok
                 except Exception as e:
                     self._save_object_error("Failed to delete dataset: %s" % e,
@@ -294,6 +295,7 @@ class SODAHarvester(HarvesterBase):
 
                     package_dict["owner_org"] = owner_org
 
+                    add_default_keys(package_dict)
                     add_default_extras(package_dict)
 
                     result = self._create_or_update_package(package_dict,

--- a/ckanext/datapress_harvester/harvesters/soda.py
+++ b/ckanext/datapress_harvester/harvesters/soda.py
@@ -1,0 +1,291 @@
+import logging
+import requests
+import hashlib
+import datetime
+
+from ckan import model
+from ckan.lib.helpers import json
+import ckan.plugins.toolkit as tk
+
+from ckanext.harvest.harvesters import HarvesterBase
+from ckanext.harvest.model import HarvestObject
+from ckan.logic import NotFound 
+
+from ckanext.datapress_harvester.util import (
+    get_package_extra_val,
+    upsert_package_extra,
+    sanitise
+)
+log = logging.getLogger(__name__)
+
+# In ckan, we should be able to add a license list such as
+# https://licenses.opendefinition.org/licenses/groups/all.json by setting the ckan.licenses_group_url field in the config, but that doesn't seem to be
+# working as we get an error at http://localhost:5000/api/3/action/license_list
+licenses = {"UK Open Government Licence v3": "OGL-UK-3.0",
+            "Public Domain": "other-pd",
+            "Open Data Commons Public Domain Dedication and License": "PDDL-1.0",
+            "Creative Commons 1.0 Universal (Public Domain Dedication)": "CC0-1.0"}
+
+formats = {"application/pdf": "pdf",
+           "application/zip": "zip",
+           "application/x-zip-compressed": "zip",
+           "text/plain": "txt",
+           "image/png": "png",
+           "application/msword": "doc",
+           "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+           "application/vnd.openxmlformats-officedocument.wordprocessingml.template": "dotx",
+           "application/vnd.ms-word.document.macroEnabled.12": "docm",
+           "application/vnd.ms-word.template.macroEnabled.12": "dotm",
+           "application/vnd.ms-excel": "xls",
+           "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+           "application/vnd.openxmlformats-officedocument.spreadsheetml.template": "xltx",
+           "application/vnd.ms-excel.sheet.macroEnabled.12": "xlsm",
+           "application/vnd.ms-excel.template.macroEnabled.12": "xltm",
+           "application/vnd.ms-excel.addin.macroEnabled.12": "xlam",
+           "application/vnd.ms-excel.sheet.binary.macroEnabled.12": "xlsb",
+           "application/vnd.ms-excel.sheet.binary.macroenabled.12": "xlsb",
+           "application/vnd.ms-powerpoint": "ppt",
+           "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+           "application/vnd.openxmlformats-officedocument.presentationml.template": "potx",
+           "application/vnd.openxmlformats-officedocument.presentationml.slideshow": "ppsx",
+           "application/vnd.ms-powerpoint.addin.macroEnabled.12": "ppam",
+           "application/vnd.ms-powerpoint.presentation.macroEnabled.12": "pptm",
+           "application/vnd.ms-powerpoint.template.macroEnabled.12": "potm",
+           "application/vnd.ms-powerpoint.slideshow.macroEnabled.12": "ppsm",}
+
+def to_iso_date(opendata_date_str):
+    dt = datetime.datetime.strptime(opendata_date_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    return dt.isoformat()
+
+class SODAHarvester(HarvesterBase):
+    url = None
+    domain = None
+    app_token = None
+    create_organisations = False
+
+    def _set_config(self, source):
+        self.url = source.url.rstrip("/")
+        self.domain = self.url.split("://")[1]
+        config = json.loads(source.config)
+        self.app_token = config["app_token"]
+        self.create_organisations = config.get("remote_orgs") == "create"
+
+    def info(self):
+        return {
+            "name": "soda",
+            "title": "Socrata Open Data API",
+            "description": "Harvests from a Socrata Open Data source",
+            "form_config_interface": "Text",
+        }
+
+    def validate_config(self, source_config):
+        source_config_obj = json.loads(source_config)
+        if not "app_token" in source_config:
+            raise ValueError("No application token provided in the 'app_token' field")
+        return source_config
+
+    def _dataset_link_info(self, ds_id, resource_name):
+        """If no valid link directly to the resource can be found, create a link to the dataset page"""
+        return {"url": f"{self.url}/dataset/{ds_id}",
+                "name": resource_name,
+                "format": "html"}
+
+    def _resource_link_info(self, ds_id, resource_name, mimetype):
+        """Get the URL, name, and resource type to display on dataset page. Where possible, this will
+        include a direct link to the resource. If we can't find the resource using ID and file type,
+        default to a link to the source dataset page."""
+        if mimetype is None:
+            format_id = "csv"
+            file_url = f"{self.url}/resource/{ds_id}.csv"
+        else:
+            format_id = formats.get(mimetype.split(";")[0])
+            file_url = f"{self.url}/download/{ds_id}/{mimetype}"
+        if format_id is None:
+            return self._dataset_link_info(ds_id, resource_name)
+        file_ok = requests.get(file_url, headers={"X-App-Token": self.app_token}).ok
+        if file_ok:
+            return {"url": file_url,
+                    "format": format_id,
+                    "name": f"{resource_name}.{format_id}"}
+        else:
+            return self._dataset_link_info(ds_id, resource_name)
+
+
+    def _create_catalog_entry(self, dataset):
+        license_name = dataset["metadata"].get("license")
+        license_id = licenses.get(license_name, license_name)
+        ds_id = dataset["resource"]["id"]
+        created_at = to_iso_date(dataset["resource"]["createdAt"])
+        modified_at = to_iso_date(dataset["resource"]["updatedAt"])
+        name = dataset["resource"]["name"]
+
+
+        resources = [{"package_id": ds_id,
+                      "created": created_at,
+                      "last_modified": modified_at,
+                      **self._resource_link_info(ds_id, name, dataset["resource"]["blob_mime_type"])}]
+        pkg_dict =  {"name": name,
+                     "package_id": ds_id,
+                     "private": False,
+                     "author": dataset["creator"]["display_name"],
+                     "maintainer": dataset["resource"]["attribution"],
+                     "maintainer_email": dataset["resource"]["contact_email"],
+                     "org_name": dataset["resource"]["attribution"],
+                     "org_link": dataset["resource"]["attribution_link"],
+                     "license_id": license_id,
+                     "license_title": license_name,
+                     "notes": dataset["resource"]["description"],
+                     "url": dataset["permalink"],
+                     "state": "active",
+                     "resources": resources}
+
+        md5 = hashlib.md5()
+        content_hash = md5.update(str(pkg_dict).encode())
+        content_hash = md5.hexdigest()
+        return {**pkg_dict, "content_hash": content_hash}
+
+    def gather_stage(self, harvest_job):
+        log.debug("In SODA harvester gather_stage (%s)", str(harvest_job))
+        self._set_config(harvest_job.source)
+        catalog_url = f"{self.url}/api/catalog/v1?domains={self.domain}"
+        batch_size = 100
+        start_index = 0
+        total_num_results = float("inf")
+        datasets = []
+        while len(datasets) < total_num_results:
+            response = requests.get(catalog_url,
+                                    headers={"X-App-Token": self.app_token},
+                                    params={"limit": batch_size, "offset": start_index})
+            if not response.ok:
+                self._save_gather_error(f"Source URL responded with {response.status_code}",
+                                        harvest_job)
+                return None
+
+            data = response.json()
+            log.info(f"Contains {len(data['results'])} items")
+            if total_num_results == float("inf"):
+                total_num_results = data["resultSetSize"]
+            datasets.extend(data["results"])
+            start_index += batch_size
+            log.info(f"Fetched {len(datasets)} out of {total_num_results} datasets")
+
+        log.info(f"Converting datasets into HarvestObjects")
+        object_ids = []
+        try:
+            for d in datasets:
+                d = self._create_catalog_entry(d)
+                obj = HarvestObject(
+                    guid=d["package_id"], job=harvest_job, content=json.dumps(d)
+                )
+                obj.save()
+                object_ids.append(obj.id)
+            return object_ids
+        except Exception as e:
+            self._save_gather_error("%r" % e.message, harvest_job)
+
+
+    def _dataset_to_pkgdict(self, dataset):
+        modified = datetime.datetime.now().isoformat()
+        return {**dataset,
+                "id": dataset["package_id"],
+                "title": dataset["name"],
+                "upstream_metadata_created": modified,
+                "upstream_metadata_modified": modified,}
+
+    def modify_package_dict(self, package_dict, harvest_object):
+        return package_dict
+
+    def fetch_stage(self, harvest_object):
+        return True
+
+    def _maybe_create_organisation(self, base_context, org_name, org_link):
+        org_id = sanitise(org_name)
+        try:
+            data_dict = {"id": org_id}
+            org = tk.get_action("organization_show")(
+                base_context.copy(), data_dict
+            )
+            return org["id"]
+        except NotFound:
+            org = {"title": org_name,
+                    "id": org_id,
+                    "name": org_id,
+                    "state": "active"}
+            if org_link is not None:
+                org = {**org,
+                        "extras": [{"key": "Website",
+                                    "value": org_link}]}
+            tk.get_action("organization_create")(base_context.copy(), org)
+            log.info(
+                "Organization %s has been newly created", org_name
+            )
+            return org["id"]
+
+    def import_stage(self, harvest_object):
+        base_context = {
+            "model": model,
+            "session": model.Session,
+            "user": self._get_user_name(),
+        }
+
+        imported_dataset = json.loads(harvest_object.content)
+
+        existing_dataset = {}
+        try:
+            existing_dataset = tk.get_action("package_show")(
+                base_context.copy(), {"id": imported_dataset["package_id"]}
+            )
+            existing_hash = get_package_extra_val(
+                existing_dataset["extras"], "content_hash"
+            )
+            if existing_hash == imported_dataset["content_hash"]:
+                log.info(f"Dataset \"{imported_dataset['name']}\" has not been changed. Skipping.")
+                return "unchanged"
+        except tk.ObjectNotFound as e:
+            log.info(f"Dataset \"{imported_dataset['name']}\" does not currently exist. Importing...")
+
+        try:
+            package_dict = {**existing_dataset, **self._dataset_to_pkgdict(imported_dataset)}
+            if self.create_organisations and package_dict["org_name"] is not None:
+                owner_org = self._maybe_create_organisation(base_context,
+                                                            package_dict.get("org_name"),
+                                                            package_dict.get("org_link"))
+            else:
+                harvest_source = tk.get_action("package_show")(
+                    base_context.copy(), {"id": harvest_object.source.id}
+                )
+                owner_org = harvest_source['organization']['name']
+
+            package_dict.pop("org_name")
+            package_dict.pop("org_link")
+            package_dict["owner_org"] = owner_org
+
+            default_keys = [
+                "author",
+                "author_email",
+                "license_id",
+                "license_title",
+                "url",
+                "version"
+            ]
+            for key in default_keys:
+                if key not in package_dict:
+                    package_dict[key] = ""
+
+            if "extras" not in package_dict:
+                package_dict["extras"] = []
+
+            if get_package_extra_val(package_dict["extras"], "data_quality") is None:
+                package_dict["extras"].append({"key": "data_quality", "value": ""})
+
+            upsert_package_extra(
+                package_dict["extras"], "content_hash", imported_dataset["content_hash"]
+            )
+
+            result = self._create_or_update_package(package_dict,
+                                                    harvest_object,
+                                                    package_dict_form="package_show")
+
+            return result
+        except Exception as e:
+            self._save_object_error("%s" % e, harvest_object, "Import")

--- a/ckanext/datapress_harvester/util/__init__.py
+++ b/ckanext/datapress_harvester/util/__init__.py
@@ -155,6 +155,22 @@ def add_existing_extras(pkg_dict, context):
 
 
 def add_default_extras(pkg_dict):
+    # Set some default keys so CKAN does not report them as being changed later.
+    default_keys = [
+        "author",
+        "author_email",
+        "license_id",
+        "license_title",
+        "url",
+        "version",
+    ]
+    for key in default_keys:
+        if key not in pkg_dict:
+            pkg_dict[key] = ""
+
+    if "extras" not in pkg_dict:
+        pkg_dict["extras"] = []
+
     # Add an empty data_quality field to extras if it's not already there
     if get_package_extra_val(pkg_dict["extras"], "data_quality") is None:
         pkg_dict["extras"].append({"key": "data_quality", "value": ""})

--- a/ckanext/datapress_harvester/util/__init__.py
+++ b/ckanext/datapress_harvester/util/__init__.py
@@ -146,7 +146,7 @@ def add_existing_extras(pkg_dict, context):
         )
     except Exception as e:
         # If the package doesn't exist, there aren't any extras to transfer
-        extras_to_transfer = {}
+        extras_to_transfer = []
 
     for e in extras_to_transfer:
         upsert_package_extra(pkg_dict["extras"], e["key"], e["value"])
@@ -154,7 +154,7 @@ def add_existing_extras(pkg_dict, context):
     return extras_to_transfer
 
 
-def add_default_extras(pkg_dict):
+def add_default_keys(pkg_dict):
     # Set some default keys so CKAN does not report them as being changed later.
     default_keys = [
         "author",
@@ -170,7 +170,10 @@ def add_default_extras(pkg_dict):
 
     if "extras" not in pkg_dict:
         pkg_dict["extras"] = []
+    return
 
+
+def add_default_extras(pkg_dict):
     # Add an empty data_quality field to extras if it's not already there
     if get_package_extra_val(pkg_dict["extras"], "data_quality") is None:
         pkg_dict["extras"].append({"key": "data_quality", "value": ""})

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
         datapress_harvester=ckanext.datapress_harvester.harvesters:DataPressHarvester
         nomis_localauthprofile=ckanext.datapress_harvester.harvesters:NomisLocalAuthorityProfileScraper
         redbridge_harvester=ckanext.datapress_harvester.harvesters:RedbridgeHarvester
+        soda_harvester=ckanext.datapress_harvester.harvesters:SODAHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel


### PR DESCRIPTION
Adds a harvester for [Socrata Open Data API discovery endpoints](https://socratadiscovery.docs.apiary.io/#), such as the one offered by [Open Data Camden](https://opendata.camden.gov.uk).

It can be configured on the new harvester form by:
- Entering a URL - so far I have only tried https://opendata.camden.gov.uk as that's all we need for this ticket
- Selecting SODA as the source type
- Adding 'app_token' to the configuration, with an application token associated with your account on the source site. We have one of these for production use (see Sven for info), but for test/development it is free and easy to create one yourself.

Socrata APIs don't have a concept of "dataset" vs "resource" - the endpoint provides a list of resources, which may have relationships to other resources. I have ignored these relationships and created one dataset per resource for now

Files are not downloaded and stored in CKAN, as this would just be a waste of space and another thing to worry about synchronising - we just link to the resource on the source.

Not all resources in the Camden source catalogue have a link to an actual file associated with them. Additionally, some have links that 404 - another GIGO situation. I have decided to treat both in the same way: if we can't get a 200 response from the resource download endpoint, we use the link to the HTML page on the source website where users can view all available information.

There's no guaruntee that this will work for other Socrata APIs, as not all of them will have a web interface that works like this, but it works for the Camden Open Data site and we can cross other bridges when we get to them.

The organisations are given only by name in the source API, so we generate IDs for them based on the name. This means that we see different organisations for different spellings of the same thing, such as "London Borough of Camden Council" and "London Borough of Camden Counil". This is a garbage-in, garbage-out situation, about which I am not inclined to do anything. Some source datasets do not have an associated organisation and will be attributed to whatever organisation was given as default in the harvester. If the organisations generated from this system are too messy, we can just omit the 'remote_orgs' key from the config and use a default organisation for all of them.