### PR TITLE
Guess image format from Content-Type header

### DIFF
--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -293,6 +293,16 @@ class DataPressHarvester(HarvesterBase):
         except Exception as e:
             return "data"
 
+    def _guess_image_format(self, url):
+        try:
+            # Get the response headers from the image url
+            # (stream=True does not download the response body immediately)
+            r = requests.get(url, stream=True)
+            content_type = r.headers["Content-Type"]
+            return content_type.split("/")[1]
+        except Exception as e:
+            return "image"
+
     def _datapress_to_ckan(self, package_dict, harvest_object):
         """
         Shims to transform DataPress packages into a format CKAN understands.
@@ -373,6 +383,9 @@ class DataPressHarvester(HarvesterBase):
 
             if "format" not in resource or not resource["format"]:
                 resource["format"] = self._resource_format_from_url(resource["url"])
+
+            if resource["format"] == "image":
+                resource["format"] = self._guess_image_format(resource["url"])
 
         # We remove the "state" key so that the current state (ie active/deleted) is
         # used instead of the state in the source. This is to prevent deleted datasets


### PR DESCRIPTION
# Resource format: image
In the London Datastore image resources are returned with `format='image'`.
This causes a problem in our CKAN because there isn't a resource icon for 'image', only icons for png, jpg and gif:
https://github.com/ckan/ckan/blob/fd88d1f4c52c8ee247883549ca23500693e2e2a4/ckan/public/base/images/sprite-resource-icons.png

## Changes
- Added a function to try and guess the image format based on the `Content-Type` header returned when downloading the image. the `stream=True` parameter in pythons `requests` library prevents the response body from being downloaded immediately (https://docs.python-requests.org/en/v1.2.3/user/advanced/#body-content-workflow)