### PR TITLE
Redbridge Harvester

### DIFF
--- a/ckanext/datapress_harvester/harvesters/__init__.py
+++ b/ckanext/datapress_harvester/harvesters/__init__.py
@@ -1,3 +1,4 @@
 from ckanext.datapress_harvester.harvesters.datapress import DataPressHarvester
 from ckanext.datapress_harvester.harvesters.nomis_localauthprofile import NomisLocalAuthorityProfileScraper
 from ckanext.datapress_harvester.harvesters.redbridge import RedbridgeHarvester
+from ckanext.datapress_harvester.harvesters.soda import SODAHarvester

--- a/ckanext/datapress_harvester/harvesters/__init__.py
+++ b/ckanext/datapress_harvester/harvesters/__init__.py
@@ -1,2 +1,3 @@
 from ckanext.datapress_harvester.harvesters.datapress import DataPressHarvester
 from ckanext.datapress_harvester.harvesters.nomis_localauthprofile import NomisLocalAuthorityProfileScraper
+from ckanext.datapress_harvester.harvesters.redbridge import RedbridgeHarvester

--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -14,7 +14,13 @@ from ckan.plugins import toolkit
 from ckanext.harvest.model import HarvestObject
 from ckanext.harvest.harvesters import HarvesterBase
 
-from ckanext.datapress_harvester.util import remove_extras, upsert_package_extra
+from ckanext.datapress_harvester.util import (
+    remove_extras,
+    upsert_package_extra,
+    get_harvested_dataset_ids,
+    add_existing_extras,
+    add_default_extras,
+)
 
 import logging
 
@@ -148,32 +154,6 @@ class DataPressHarvester(HarvesterBase):
         """
         return package_dict
 
-    def _harvester_search_dict(self, source_id, page, limit):
-        return {
-            "fq": '+harvest_source_id:"{0}"'.format(source_id),
-            "fl": "id",
-            "rows": limit,
-            "start": (page - 1) * limit,
-        }
-
-    def _get_harvested_dataset_ids(self, harvest_source_id):
-        context = {"model": model, "session": model.Session}
-        page = 1
-        limit = 1000
-        query_result = toolkit.get_action("package_search")(
-            context,
-            self._harvester_search_dict(harvest_source_id, page, limit),
-        )
-        log.info(f"{query_result['count']} datasets harvested previously")
-        datasets = query_result["results"]
-        while len(datasets) < query_result["count"]:
-            page += 1
-            datasets += toolkit.get_action("package_search")(
-                context, self._harvester_search_dict(harvest_source_id, page, limit)
-            )["results"]
-
-        return {d["id"] for d in datasets}
-
     def gather_stage(self, harvest_job):
         log.debug("In DataPressHarvester gather_stage (%s)", harvest_job.source.url)
         toolkit.requires_ckan_version(min_version="2.0")
@@ -217,7 +197,7 @@ class DataPressHarvester(HarvesterBase):
         fetched_ids = {p["id"] for p in pkg_dicts}
 
         # Get the Set of ids of datasets in the database that belong to this harvest source
-        existing_dataset_ids = self._get_harvested_dataset_ids(harvest_job.source.id)
+        existing_dataset_ids = get_harvested_dataset_ids(harvest_job.source.id)
 
         # Datasets that are present locally but not upstream need to be deleted locally
         to_be_deleted = existing_dataset_ids - fetched_ids
@@ -413,29 +393,6 @@ class DataPressHarvester(HarvesterBase):
                 )
                 return True
 
-            try:
-                # Check whether a package already exists that we need to transfer the extras from:
-                existing_package = toolkit.get_action("package_show")(
-                    base_context.copy(),
-                    {"id": package_dict["id"], "use_default_schema": True},
-                )
-
-                # These extras keys *should* be updated on every run of the harvester
-                remove_from_extras = [
-                    "upstream_metadata_created",
-                    "upstream_metadata_modified",
-                    "upstream_url",
-                    "harvest_object_id",
-                    "harvest_source_id",
-                    "harvest_source_title",
-                ]
-                extras_to_transfer = remove_extras(
-                    existing_package["extras"], remove_from_extras
-                )
-            except Exception as e:
-                # If the package doesn't exist, there aren't any extras to transfer
-                extras_to_transfer = {}
-
             package_dict = self._datapress_to_ckan(package_dict, harvest_object)
 
             if package_dict.get("type") == "harvest":
@@ -614,8 +571,10 @@ class DataPressHarvester(HarvesterBase):
             # Add any existing extras here so they override any default extras
             # specified in the harvest source. E.g. if data_quality is set as a default_extra
             # we want to override that with whatever the current value is.
-            for e in extras_to_transfer:
-                upsert_package_extra(package_dict["extras"], e["key"], e["value"])
+            add_existing_extras(package_dict, base_context.copy())
+
+            # Add some default extras
+            add_default_extras(package_dict)
 
             package_dict["extras"] += [
                 {

--- a/ckanext/datapress_harvester/harvesters/nomis_localauthprofile.py
+++ b/ckanext/datapress_harvester/harvesters/nomis_localauthprofile.py
@@ -19,6 +19,8 @@ from ckanext.datapress_harvester.util import (
     sanitise,
     get_package_extra_val,
     upsert_package_extra,
+    add_default_extras,
+    add_existing_extras,
 )
 
 log = logging.getLogger(__name__)
@@ -321,9 +323,11 @@ class NomisLocalAuthorityProfileScraper(HarvesterBase):
             if "extras" not in package_dict:
                 package_dict["extras"] = []
 
-            # Add an empty data quality field to extras if it's not already there
-            if get_package_extra_val(package_dict["extras"], "data_quality") is None:
-                package_dict["extras"].append({"key": "data_quality", "value": ""})
+            # Add any package[extras] from a preexisting version of this dataset
+            add_existing_extras(package_dict, base_context.copy())
+
+            # Add some default package[extras]
+            add_default_extras(package_dict)
 
             # Add the content hash or update the value if one existed
             upsert_package_extra(

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -15,6 +15,7 @@ from ckanext.datapress_harvester.util import (
     upsert_package_extra,
     get_package_extra_val,
     get_harvested_dataset_ids,
+    add_default_keys,
     add_default_extras,
     add_existing_extras,
 )
@@ -193,7 +194,7 @@ class RedbridgeHarvester(HarvesterBase):
 
         try:
             package_dict = json.loads(harvest_object.content)
-            if package_dict["action"] == "delete":
+            if package_dict.get("action", None) == "delete":
                 log.info(f"Deleting dataset with ID: {package_dict['id']}")
                 result = toolkit.get_action("dataset_purge")(
                     base_context.copy(), package_dict
@@ -205,14 +206,13 @@ class RedbridgeHarvester(HarvesterBase):
             )
 
         try:
-            # Merge our scraped package dict into any existing package dict
-            # The keys in the dict returned by _dataset_to_pkgdict will override those in existing_dataset
-
             # Set the owner org of the new dataset to the org set in the harvest source
             harvest_source = toolkit.get_action("package_show")(
                 base_context.copy(), {"id": harvest_object.source.id}
             )
             package_dict["owner_org"] = harvest_source.get("owner_org")
+
+            add_default_keys(package_dict)
 
             add_existing_extras(package_dict, base_context.copy())
 

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -1,0 +1,236 @@
+import logging
+import requests
+import hashlib
+import xmltodict
+
+from ckan import model
+from ckan.lib.helpers import json
+import ckan.plugins.toolkit as toolkit
+
+from ckanext.harvest.harvesters import HarvesterBase
+from ckanext.harvest.model import HarvestObject
+
+from ckanext.datapress_harvester.util import (
+    remove_extras,
+    upsert_package_extra,
+    get_package_extra_val,
+    get_harvested_dataset_ids,
+    add_default_extras,
+    add_existing_extras,
+)
+
+log = logging.getLogger(__name__)
+
+REDBRIDGE_API_URL = "http://data.redbridge.gov.uk/api/"
+
+
+def _generate_resource(package_id, dataset, is_csv):
+    """Generate a resource dict for use in a package_dict"""
+    url = dataset["FriendlyUrl"]
+    if is_csv:
+        url = url.replace("XML", "CSV")
+
+    sha1 = hashlib.sha1()
+    resource_id = sha1.update(url.encode())
+    resource_id = sha1.hexdigest()
+
+    return {
+        "id": resource_id,
+        "package_id": package_id,
+        "url": url,
+        "name": dataset["Title"],
+        "metedata_modified": dataset["DateUpdated"],
+        "last_modified": dataset["DateUpdated"],
+        "format": "csv" if is_csv else "xml",
+    }
+
+
+class RedbridgeHarvester(HarvesterBase):
+    def info(self):
+        return {
+            "name": "redbridge",
+            "title": "Redbridge",
+            "description": "Harvests from Redbridge's DataShare API",
+            "form_config_interface": "Text",
+        }
+
+    def gather_stage(self, harvest_job):
+        pkg_dicts = []
+
+        try:
+            response = requests.get(REDBRIDGE_API_URL)
+        except requests.exceptions.ConnectionError as e:
+            self._save_gather_error(
+                f"Connection error for Redbridge API: {REDBRIDGE_API_URL}",
+                harvest_job,
+            )
+            return pkg_dicts
+
+        category_urls = [
+            f"{REDBRIDGE_API_URL}{c['FriendlyUrl']}"
+            for c in xmltodict.parse(response.text)["ArrayOfRestCategory"][
+                "RestCategory"
+            ]
+        ]
+
+        # TODO Write some notes on the Redbridge API because I'm never going to remember how it works!
+
+        for c in category_urls:
+            try:
+                category = requests.get(c)
+            except requests.exceptions.ConnectionError as e:
+                self._save_gather_error(
+                    f"Connection error for category: {c}",
+                    harvest_job,
+                )
+                continue
+
+            schemas = xmltodict.parse(category.text)["ArrayOfRestSchema"]["RestSchema"]
+            if not isinstance(schemas, list):
+                schemas = [schemas]
+
+            for s in schemas:
+                schema_title = s["Title"]
+                schema_description = s["ShortDescription"]
+
+                datasets_url = f"{c}/{s['FriendlyUrl']}"
+
+                try:
+                    datasets = requests.get(datasets_url)
+                except requests.exceptions.ConnectionError as e:
+                    self._save_gather_error(
+                        f"Connection error for category: {datasets_url}",
+                        harvest_job,
+                    )
+                    continue
+
+                datasets_metadata = xmltodict.parse(datasets.text)[
+                    "ArrayOfRestDataSet"
+                ]["RestDataSet"]
+                if not isinstance(datasets_metadata, list):
+                    datasets_metadata = [datasets_metadata]
+
+                for d in datasets_metadata:
+                    full_title = f"Redbrige - {schema_title} - {d['Title']}"
+                    sha1 = hashlib.sha1()
+                    package_id = sha1.update(full_title.encode())
+                    package_id = sha1.hexdigest()
+
+                    package_dict = {
+                        "id": package_id,
+                        "title": full_title,
+                        "name": full_title,
+                        "notes": schema_description,
+                        "license_id": "uk-ogl",
+                        "metadata_modified": d["DateUpdated"],
+                        "upstream_metadata_created": d["DateUpdated"],
+                        "upstream_metadata_modified": d["DateUpdated"],
+                        "resources": [
+                            _generate_resource(package_id, d, is_csv=False),
+                            _generate_resource(package_id, d, is_csv=True),
+                        ],
+                    }
+                    pkg_dicts.append(package_dict)
+
+        # Create a Set of dataset ids fetched from upstream,
+        # for comparing with those that have been harvested previously and are already in the database
+        fetched_ids = {p["id"] for p in pkg_dicts}
+
+        # Get the Set of ids of datasets in the database that belong to this harvest source
+        existing_dataset_ids = get_harvested_dataset_ids(harvest_job.source.id)
+
+        # Datasets that are present locally but not upstream need to be deleted locally
+        to_be_deleted = existing_dataset_ids - fetched_ids
+        log.info(f"{len(to_be_deleted)} datasets need to be deleted")
+
+        # Create harvest objects for each dataset
+        object_ids = []
+        try:
+            for p in pkg_dicts:
+                obj = HarvestObject(
+                    guid=p["id"], job=harvest_job, content=json.dumps(p)
+                )
+                obj.save()
+                object_ids.append(obj.id)
+
+            for i in to_be_deleted:
+                # the dataset_purge function in the import_stage only needs the dataset ID to be able to purge the dataset.
+                pkg_dict = {"id": i, "action": "delete"}
+                obj = HarvestObject(
+                    guid=i, job=harvest_job, content=json.dumps(pkg_dict)
+                )
+                obj.save()
+                object_ids.append(obj.id)
+            return object_ids
+        except Exception as e:
+            self._save_gather_error("%r" % e.message, harvest_job)
+
+    def fetch_stage(self, harvest_object):
+        return True
+
+    def import_stage(self, harvest_object):
+        base_context = {
+            "model": model,
+            "session": model.Session,
+            "user": self._get_user_name(),
+        }
+        if not harvest_object:
+            log.error("No harvest object received")
+            return False
+
+        if harvest_object.content is None:
+            self._save_object_error(
+                "Empty content for object %s" % harvest_object.id,
+                harvest_object,
+                "Import",
+            )
+            return False
+
+        try:
+            package_dict = json.loads(harvest_object.content)
+            if package_dict["action"] == "delete":
+                log.info(f"Deleting dataset with ID: {package_dict['id']}")
+                result = toolkit.get_action("dataset_purge")(
+                    base_context.copy(), package_dict
+                )
+                return True
+        except Exception as e:
+            self._save_object_error(
+                "Failed to parse harvest object: %s" % e, harvest_object, "Import"
+            )
+
+        try:
+            # Merge our scraped package dict into any existing package dict
+            # The keys in the dict returned by _dataset_to_pkgdict will override those in existing_dataset
+
+            # Set the owner org of the new dataset to the org set in the harvest source
+            harvest_source = toolkit.get_action("package_show")(
+                base_context.copy(), {"id": harvest_object.source.id}
+            )
+            package_dict["owner_org"] = harvest_source.get("owner_org")
+
+            # Set some default keys so CKAN does not report them as being changed later.
+            default_keys = [
+                "author",
+                "author_email",
+                "url",
+                "version",
+            ]
+            for key in default_keys:
+                if key not in package_dict:
+                    package_dict[key] = ""
+
+            if "extras" not in package_dict:
+                package_dict["extras"] = []
+
+            add_existing_extras(package_dict, base_context.copy())
+
+            add_default_extras(package_dict)
+
+            result = self._create_or_update_package(
+                package_dict, harvest_object, package_dict_form="package_show"
+            )
+
+            return result
+        except Exception as e:
+            self._save_object_error("%s" % e, harvest_object, "Import")

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -214,20 +214,6 @@ class RedbridgeHarvester(HarvesterBase):
             )
             package_dict["owner_org"] = harvest_source.get("owner_org")
 
-            # Set some default keys so CKAN does not report them as being changed later.
-            default_keys = [
-                "author",
-                "author_email",
-                "url",
-                "version",
-            ]
-            for key in default_keys:
-                if key not in package_dict:
-                    package_dict[key] = ""
-
-            if "extras" not in package_dict:
-                package_dict["extras"] = []
-
             add_existing_extras(package_dict, base_context.copy())
 
             add_default_extras(package_dict)

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -66,14 +66,19 @@ class RedbridgeHarvester(HarvesterBase):
             )
             return pkg_dicts
 
+        # The Redbrige API doesn't have a single "list all datasets" endpoint,
+        # you have to go through a bit of a convoluted paths from "categories" to
+        # "schemas" to "datasets".
+        #
+        # The rest of the code in this function finds all the datasets served by
+        # the Redbridge API and converts them into a package_dict-like thing.
+
         category_urls = [
             f"{REDBRIDGE_API_URL}{c['FriendlyUrl']}"
             for c in xmltodict.parse(response.text)["ArrayOfRestCategory"][
                 "RestCategory"
             ]
         ]
-
-        # TODO Write some notes on the Redbridge API because I'm never going to remember how it works!
 
         for c in category_urls:
             try:

--- a/ckanext/datapress_harvester/harvesters/soda.py
+++ b/ckanext/datapress_harvester/harvesters/soda.py
@@ -16,6 +16,7 @@ from ckanext.datapress_harvester.util import (
     upsert_package_extra,
     sanitise,
     get_harvested_dataset_ids,
+    add_default_keys,
     add_default_extras,
     add_existing_extras
 )
@@ -270,7 +271,7 @@ class SODAHarvester(HarvesterBase):
             case "delete":
                 try:
                     ok = self._delete_dataset(base_context.copy(), imported_dataset)
-                    log.info("Successfullt deleted")
+                    log.info("Successfully deleted")
                     return ok
                 except Exception as e:
                     self._save_object_error("Failed to delete dataset: %s" % e,
@@ -294,6 +295,7 @@ class SODAHarvester(HarvesterBase):
 
                     package_dict["owner_org"] = owner_org
 
+                    add_default_keys(package_dict)
                     add_default_extras(package_dict)
 
                     result = self._create_or_update_package(package_dict,

--- a/ckanext/datapress_harvester/harvesters/soda.py
+++ b/ckanext/datapress_harvester/harvesters/soda.py
@@ -1,0 +1,291 @@
+import logging
+import requests
+import hashlib
+import datetime
+
+from ckan import model
+from ckan.lib.helpers import json
+import ckan.plugins.toolkit as tk
+
+from ckanext.harvest.harvesters import HarvesterBase
+from ckanext.harvest.model import HarvestObject
+from ckan.logic import NotFound 
+
+from ckanext.datapress_harvester.util import (
+    get_package_extra_val,
+    upsert_package_extra,
+    sanitise
+)
+log = logging.getLogger(__name__)
+
+# In ckan, we should be able to add a license list such as
+# https://licenses.opendefinition.org/licenses/groups/all.json by setting the ckan.licenses_group_url field in the config, but that doesn't seem to be
+# working as we get an error at http://localhost:5000/api/3/action/license_list
+licenses = {"UK Open Government Licence v3": "OGL-UK-3.0",
+            "Public Domain": "other-pd",
+            "Open Data Commons Public Domain Dedication and License": "PDDL-1.0",
+            "Creative Commons 1.0 Universal (Public Domain Dedication)": "CC0-1.0"}
+
+formats = {"application/pdf": "pdf",
+           "application/zip": "zip",
+           "application/x-zip-compressed": "zip",
+           "text/plain": "txt",
+           "image/png": "png",
+           "application/msword": "doc",
+           "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+           "application/vnd.openxmlformats-officedocument.wordprocessingml.template": "dotx",
+           "application/vnd.ms-word.document.macroEnabled.12": "docm",
+           "application/vnd.ms-word.template.macroEnabled.12": "dotm",
+           "application/vnd.ms-excel": "xls",
+           "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+           "application/vnd.openxmlformats-officedocument.spreadsheetml.template": "xltx",
+           "application/vnd.ms-excel.sheet.macroEnabled.12": "xlsm",
+           "application/vnd.ms-excel.template.macroEnabled.12": "xltm",
+           "application/vnd.ms-excel.addin.macroEnabled.12": "xlam",
+           "application/vnd.ms-excel.sheet.binary.macroEnabled.12": "xlsb",
+           "application/vnd.ms-excel.sheet.binary.macroenabled.12": "xlsb",
+           "application/vnd.ms-powerpoint": "ppt",
+           "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+           "application/vnd.openxmlformats-officedocument.presentationml.template": "potx",
+           "application/vnd.openxmlformats-officedocument.presentationml.slideshow": "ppsx",
+           "application/vnd.ms-powerpoint.addin.macroEnabled.12": "ppam",
+           "application/vnd.ms-powerpoint.presentation.macroEnabled.12": "pptm",
+           "application/vnd.ms-powerpoint.template.macroEnabled.12": "potm",
+           "application/vnd.ms-powerpoint.slideshow.macroEnabled.12": "ppsm",}
+
+def to_iso_date(opendata_date_str):
+    dt = datetime.datetime.strptime(opendata_date_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    return dt.isoformat()
+
+class SODAHarvester(HarvesterBase):
+    url = None
+    domain = None
+    app_token = None
+    create_organisations = False
+
+    def _set_config(self, source):
+        self.url = source.url.rstrip("/")
+        self.domain = self.url.split("://")[1]
+        config = json.loads(source.config)
+        self.app_token = config["app_token"]
+        self.create_organisations = config.get("remote_orgs") == "create"
+
+    def info(self):
+        return {
+            "name": "soda",
+            "title": "Socrata Open Data API",
+            "description": "Harvests from a Socrata Open Data source",
+            "form_config_interface": "Text",
+        }
+
+    def validate_config(self, source_config):
+        source_config_obj = json.loads(source_config)
+        if not "app_token" in source_config:
+            raise ValueError("No application token provided in the 'app_token' field")
+        return source_config
+
+    def _dataset_link_info(self, ds_id, resource_name):
+        """If no valid link directly to the resource can be found, create a link to the dataset page"""
+        return {"url": f"{self.url}/dataset/{ds_id}",
+                "name": resource_name,
+                "format": "html"}
+
+    def _resource_link_info(self, ds_id, resource_name, mimetype):
+        """Get the URL, name, and resource type to display on dataset page. Where possible, this will
+        include a direct link to the resource. If we can't find the resource using ID and file type,
+        default to a link to the source dataset page."""
+        if mimetype is None:
+            format_id = "csv"
+            file_url = f"{self.url}/resource/{ds_id}.csv"
+        else:
+            format_id = formats.get(mimetype.split(";")[0])
+            file_url = f"{self.url}/download/{ds_id}/{mimetype}"
+        if format_id is None:
+            return self._dataset_link_info(ds_id, resource_name)
+        file_ok = requests.get(file_url, headers={"X-App-Token": self.app_token}).ok
+        if file_ok:
+            return {"url": file_url,
+                    "format": format_id,
+                    "name": f"{resource_name}.{format_id}"}
+        else:
+            return self._dataset_link_info(ds_id, resource_name)
+
+
+    def _create_catalog_entry(self, dataset):
+        license_name = dataset["metadata"].get("license")
+        license_id = licenses.get(license_name, license_name)
+        ds_id = dataset["resource"]["id"]
+        created_at = to_iso_date(dataset["resource"]["createdAt"])
+        modified_at = to_iso_date(dataset["resource"]["updatedAt"])
+        name = dataset["resource"]["name"]
+
+
+        resources = [{"package_id": ds_id,
+                      "created": created_at,
+                      "last_modified": modified_at,
+                      **self._resource_link_info(ds_id, name, dataset["resource"]["blob_mime_type"])}]
+        pkg_dict =  {"name": name,
+                     "package_id": ds_id,
+                     "private": False,
+                     "author": dataset["creator"]["display_name"],
+                     "maintainer": dataset["resource"]["attribution"],
+                     "maintainer_email": dataset["resource"]["contact_email"],
+                     "org_name": dataset["resource"]["attribution"],
+                     "org_link": dataset["resource"]["attribution_link"],
+                     "license_id": license_id,
+                     "license_title": license_name,
+                     "notes": dataset["resource"]["description"],
+                     "url": dataset["permalink"],
+                     "state": "active",
+                     "resources": resources}
+
+        md5 = hashlib.md5()
+        content_hash = md5.update(str(pkg_dict).encode())
+        content_hash = md5.hexdigest()
+        return {**pkg_dict, "content_hash": content_hash}
+
+    def gather_stage(self, harvest_job):
+        log.debug("In SODA harvester gather_stage (%s)", str(harvest_job))
+        self._set_config(harvest_job.source)
+        catalog_url = f"{self.url}/api/catalog/v1?domains={self.domain}"
+        batch_size = 100
+        start_index = 0
+        total_num_results = float("inf")
+        datasets = []
+        while len(datasets) < total_num_results:
+            response = requests.get(catalog_url,
+                                    headers={"X-App-Token": self.app_token},
+                                    params={"limit": batch_size, "offset": start_index})
+            if not response.ok:
+                self._save_gather_error(f"Source URL responded with {response.status_code}",
+                                        harvest_job)
+                return None
+
+            data = response.json()
+            log.info(f"Contains {len(data['results'])} items")
+            if total_num_results == float("inf"):
+                total_num_results = data["resultSetSize"]
+            datasets.extend(data["results"])
+            start_index += batch_size
+            log.info(f"Fetched {len(datasets)} out of {total_num_results} datasets")
+
+        log.info(f"Converting datasets into HarvestObjects")
+        object_ids = []
+        try:
+            for d in datasets:
+                d = self._create_catalog_entry(d)
+                obj = HarvestObject(
+                    guid=d["package_id"], job=harvest_job, content=json.dumps(d)
+                )
+                obj.save()
+                object_ids.append(obj.id)
+            return object_ids
+        except Exception as e:
+            self._save_gather_error("%r" % e.message, harvest_job)
+
+
+    def _dataset_to_pkgdict(self, dataset):
+        modified = datetime.datetime.now().isoformat()
+        return {**dataset,
+                "id": dataset["package_id"],
+                "title": dataset["name"],
+                "upstream_metadata_created": modified,
+                "upstream_metadata_modified": modified,}
+
+    def modify_package_dict(self, package_dict, harvest_object):
+        return package_dict
+
+    def fetch_stage(self, harvest_object):
+        return True
+
+    def _maybe_create_organisation(self, base_context, org_name, org_link):
+        org_id = sanitise(org_name)
+        try:
+            data_dict = {"id": org_id}
+            org = tk.get_action("organization_show")(
+                base_context.copy(), data_dict
+            )
+            return org["id"]
+        except NotFound:
+            org = {"title": org_name,
+                    "id": org_id,
+                    "name": org_id,
+                    "state": "active"}
+            if org_link is not None:
+                org = {**org,
+                        "extras": [{"key": "Website",
+                                    "value": org_link}]}
+            tk.get_action("organization_create")(base_context.copy(), org)
+            log.info(
+                "Organization %s has been newly created", org_name
+            )
+            return org["id"]
+
+    def import_stage(self, harvest_object):
+        base_context = {
+            "model": model,
+            "session": model.Session,
+            "user": self._get_user_name(),
+        }
+
+        imported_dataset = json.loads(harvest_object.content)
+
+        existing_dataset = {}
+        try:
+            existing_dataset = tk.get_action("package_show")(
+                base_context.copy(), {"id": imported_dataset["package_id"]}
+            )
+            existing_hash = get_package_extra_val(
+                existing_dataset["extras"], "content_hash"
+            )
+            if existing_hash == imported_dataset["content_hash"]:
+                log.info(f"Dataset \"{imported_dataset['name']}\" has not been changed. Skipping.")
+                return "unchanged"
+        except tk.ObjectNotFound as e:
+            log.info(f"Dataset \"{imported_dataset['name']}\" does not currently exist. Importing...")
+
+        try:
+            package_dict = {**existing_dataset, **self._dataset_to_pkgdict(imported_dataset)}
+            if self.create_organisations and package_dict["org_name"] is not None:
+                owner_org = self._maybe_create_organisation(base_context,
+                                                            package_dict.get("org_name"),
+                                                            package_dict.get("org_link"))
+            else:
+                harvest_source = tk.get_action("package_show")(
+                    base_context.copy(), {"id": harvest_object.source.id}
+                )
+                owner_org = harvest_source['organization']['name']
+
+            package_dict.pop("org_name")
+            package_dict.pop("org_link")
+            package_dict["owner_org"] = owner_org
+
+            default_keys = [
+                "author",
+                "author_email",
+                "license_id",
+                "license_title",
+                "url",
+                "version"
+            ]
+            for key in default_keys:
+                if key not in package_dict:
+                    package_dict[key] = ""
+
+            if "extras" not in package_dict:
+                package_dict["extras"] = []
+
+            if get_package_extra_val(package_dict["extras"], "data_quality") is None:
+                package_dict["extras"].append({"key": "data_quality", "value": ""})
+
+            upsert_package_extra(
+                package_dict["extras"], "content_hash", imported_dataset["content_hash"]
+            )
+
+            result = self._create_or_update_package(package_dict,
+                                                    harvest_object,
+                                                    package_dict_form="package_show")
+
+            return result
+        except Exception as e:
+            self._save_object_error("%s" % e, harvest_object, "Import")

--- a/ckanext/datapress_harvester/util/__init__.py
+++ b/ckanext/datapress_harvester/util/__init__.py
@@ -155,6 +155,22 @@ def add_existing_extras(pkg_dict, context):
 
 
 def add_default_extras(pkg_dict):
+    # Set some default keys so CKAN does not report them as being changed later.
+    default_keys = [
+        "author",
+        "author_email",
+        "license_id",
+        "license_title",
+        "url",
+        "version",
+    ]
+    for key in default_keys:
+        if key not in pkg_dict:
+            pkg_dict[key] = ""
+
+    if "extras" not in pkg_dict:
+        pkg_dict["extras"] = []
+
     # Add an empty data_quality field to extras if it's not already there
     if get_package_extra_val(pkg_dict["extras"], "data_quality") is None:
         pkg_dict["extras"].append({"key": "data_quality", "value": ""})

--- a/ckanext/datapress_harvester/util/__init__.py
+++ b/ckanext/datapress_harvester/util/__init__.py
@@ -146,7 +146,7 @@ def add_existing_extras(pkg_dict, context):
         )
     except Exception as e:
         # If the package doesn't exist, there aren't any extras to transfer
-        extras_to_transfer = {}
+        extras_to_transfer = []
 
     for e in extras_to_transfer:
         upsert_package_extra(pkg_dict["extras"], e["key"], e["value"])
@@ -154,7 +154,7 @@ def add_existing_extras(pkg_dict, context):
     return extras_to_transfer
 
 
-def add_default_extras(pkg_dict):
+def add_default_keys(pkg_dict):
     # Set some default keys so CKAN does not report them as being changed later.
     default_keys = [
         "author",
@@ -170,7 +170,10 @@ def add_default_extras(pkg_dict):
 
     if "extras" not in pkg_dict:
         pkg_dict["extras"] = []
+    return
 
+
+def add_default_extras(pkg_dict):
     # Add an empty data_quality field to extras if it's not already there
     if get_package_extra_val(pkg_dict["extras"], "data_quality") is None:
         pkg_dict["extras"].append({"key": "data_quality", "value": ""})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+xmltodict

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
         [ckan.plugins]
         datapress_harvester=ckanext.datapress_harvester.harvesters:DataPressHarvester
         nomis_localauthprofile=ckanext.datapress_harvester.harvesters:NomisLocalAuthorityProfileScraper
+        redbridge_harvester=ckanext.datapress_harvester.harvesters:RedbridgeHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
         datapress_harvester=ckanext.datapress_harvester.harvesters:DataPressHarvester
         nomis_localauthprofile=ckanext.datapress_harvester.harvesters:NomisLocalAuthorityProfileScraper
         redbridge_harvester=ckanext.datapress_harvester.harvesters:RedbridgeHarvester
+        soda_harvester=ckanext.datapress_harvester.harvesters:SODAHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel


### PR DESCRIPTION
# Redbridge Harvester
This is very similar to the other harvesters. The Redbridge API doesn't have a single "get all datasets" API endpoint, so the process of finding all the available datasets is a bit convoluted. But once the package_dicts are created the import process is pretty standard.

I've moved a few things out of the `datapress` and `nomis` harvesters and into the `util` module to try and make it easier to do the things that need doing for most harvesters. There's some common functionality getting spread around the different harvesters that it would be good to try and have in one place. I'm not sure if `util` is the best place but hopefully it'll do for now.

There are a couple of `util` things that I think might need to be added to the Camden harvester:
 - The bit that checks for datasets that have been deleted upstream and removes them from the local CKAN (e.g. lines 145-149 of `redbridge.py` and some bits in the import stage)
 - The bit that transfers across any existing package_extras (e.g, line 231 of `redbridge.py`)