### PR TITLE
Harvest private datapress datasets

### DIFF
--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -146,6 +146,10 @@ class DataPressHarvester(HarvesterBase):
                 if not isinstance(config_obj["datapress_api_key"], str):
                     raise ValueError("datapress_api_key must be string")
 
+            if "harvest_private_datasets" in config_obj:
+                if not isinstance(config_obj["harvest_private_datasets"], bool):
+                    raise ValueError("harvest_private_datasets must be boolean")
+
         except ValueError as e:
             raise e
 
@@ -224,10 +228,9 @@ class DataPressHarvester(HarvesterBase):
             package_ids = set()
             object_ids = []
 
-            # Don't harvest anything marked as private
-            # (Not sure why private datasets are being returned by the datapress public API)
             for pkg_dict in pkg_dicts:
-                if pkg_dict["private"]:
+                if pkg_dict["private"] and not self.config.get('harvest_private_datasets'):
+                    log.info('Discarding private dataset %s %s', {pkg_dict["name"]}, {pkg_dict["id"]})
                     continue
 
                 if pkg_dict["id"] in package_ids:

--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -142,6 +142,10 @@ class DataPressHarvester(HarvesterBase):
                 if not isinstance(config_obj["read_only"], bool):
                     raise ValueError("read_only must be boolean")
 
+            if "datapress_api_key" in config_obj:
+                if not isinstance(config_obj["datapress_api_key"], str):
+                    raise ValueError("datapress_api_key must be string")
+
         except ValueError as e:
             raise e
 
@@ -153,6 +157,18 @@ class DataPressHarvester(HarvesterBase):
         creating or updating the actual package.
         """
         return package_dict
+
+    def request_jwt_token(self,remote_datapress_base_url):
+        """
+        Request a datapress JWT token from its undocumented /api/whoami route.
+        Data press developers were consulted by Sven Latham, and it seems this is
+        the recommended method.
+        """
+        url_route = f'{remote_datapress_base_url}/api/whoami'
+        json_response = requests.get(url_route,headers={'Authorization': self.config['datapress_api_key'] }).json()
+        jwt_token = json_response['readonly']['libraryJwt']
+        #log.debug(f'JWT token: {jwt_token}')
+        return jwt_token
 
     def gather_stage(self, harvest_job):
         log.debug("In DataPressHarvester gather_stage (%s)", harvest_job.source.url)
@@ -255,9 +271,26 @@ class DataPressHarvester(HarvesterBase):
 
     def _fetch_packages(self, remote_datapress_base_url):
         """Fetch the current package list from DataPress"""
+
+        if self.config.get('datapress_api_key'):
+            # NOTE: Data press uses a non-standard 'Identity' HTTP
+            # header that we need to use to pass the JWT
+            # authentication token.
+            #
+            # If you don't pass this token in this header, datapress
+            # will not reveal organisation/collaborator datasets that
+            # the user with this API key should be able to see.
+            request_headers = {'Identity': self.request_jwt_token(remote_datapress_base_url)}
+        else:
+            request_headers = {}
+
+        # This route is datapress's CKAN compatibility API (it does not support all CKANs flags)
+        # Datapress documentation for this route can be found here:
+        #
+        # https://datapress.gitbook.io/datapress/ckan-requests
         url = f"{remote_datapress_base_url}/api/action/current_package_list_with_resources"
         log.debug("Fetching DataPress datasets: %s", url)
-        data = requests.get(url).json()
+        data = requests.get(url,headers=request_headers).json()
         assert data["success"]
         return data["result"]
 

--- a/docs/harvester_config.md
+++ b/docs/harvester_config.md
@@ -24,6 +24,13 @@ token to authenticate requests to Datapress.
 
 This API key is required to access specific private datasets.
 
+`harvest_private_datasets`
+
+This key if provided should be a boolean value, indicating whether or
+not the harvester should store metadata on private datasets that the
+harvester has fetched. The default value for this is `false`
+indicating that private datasets won't be indexed.
+
 ## CKAN
 
 `remote_orgs`

--- a/docs/harvester_config.md
+++ b/docs/harvester_config.md
@@ -31,6 +31,11 @@ not the harvester should store metadata on private datasets that the
 harvester has fetched. The default value for this is `false`
 indicating that private datasets won't be indexed.
 
+As the Datapress harvester is a fork of the CKAN harvester it also
+supports many of the configuration options listed on the [CKAN harvester plugin
+repository](https://github.com/ckan/ckanext-harvest?tab=readme-ov-file#the-ckan-harvester)
+however these options have not yet been tested.
+
 ## CKAN
 
 `remote_orgs`

--- a/docs/harvester_config.md
+++ b/docs/harvester_config.md
@@ -15,6 +15,14 @@ enables the harvester to import remote organizations. Setting it to
 'create' will make an attempt to create the organizations by copying
 the details from the remote CKAN.
 
+`datapress_api_key`
+
+This optional key if provided should be a string containing a
+DataPress API key. If the key is provided the harvester will use the
+key to request a JWT token from DataPress, and will then use that
+token to authenticate requests to Datapress.
+
+This API key is required to access specific private datasets.
 
 ## CKAN
 

--- a/docs/harvester_config.md
+++ b/docs/harvester_config.md
@@ -36,6 +36,22 @@ supports many of the configuration options listed on the [CKAN harvester plugin
 repository](https://github.com/ckan/ckanext-harvest?tab=readme-ov-file#the-ckan-harvester)
 however these options have not yet been tested.
 
+An example configuration for harvesting private datasets with an API
+key is provided below:
+
+```json
+{"remote_orgs":"create",
+ "datapress_api_key":"<API_KEY>",
+ "harvest_private_datasets": true}
+```
+
+An example for harvesting a public datapress site ignoring private
+datasets, is provided below:
+
+```json
+{"remote_orgs":"create"}
+```
+
 ## CKAN
 
 `remote_orgs`
@@ -52,13 +68,6 @@ to work.
 
 ## SODA
 
-E.g.
-
-```json
-{"app_token": "<TOKEN_HERE>", "remote_orgs": "create"}
-```
-
-
 `remote_orgs`
 
 By default, remote organizations are ignored. Setting this property
@@ -69,6 +78,13 @@ the details from the remote CKAN.
 `app_token` - All requests should include an app token that identifies
 your application, and each application should have its own unique app
 token. See [Socrata Developer Portal](https://dev.socrata.com/foundry/opendata.camden.gov.uk/uqwb-mdhe/embed)
+
+E.g.
+
+```json
+{"app_token": "<TOKEN_HERE>", "remote_orgs": "create"}
+```
+
 
 ## Redbridge and NOMIS
 

--- a/docs/harvester_config.md
+++ b/docs/harvester_config.md
@@ -1,0 +1,55 @@
+# Harvester Configuration
+
+CKAN harvesters can optionally accept configuration as a JSON object.
+This can be provided when they are created in the CKAN admin panel.
+
+This document describes the configuration options supported by our
+harvesters.
+
+## Datapress
+
+`remote_orgs`
+
+By default, remote organizations are ignored. Setting this property
+enables the harvester to import remote organizations. Setting it to
+'create' will make an attempt to create the organizations by copying
+the details from the remote CKAN.
+
+
+## CKAN
+
+`remote_orgs`
+
+By default, remote organizations are ignored. Setting this property
+enables the harvester to import remote organizations. Setting it to
+'create' will make an attempt to create the organizations by copying
+the details from the remote CKAN.
+
+
+In addition the following default flags documented on [CKAN harvester plugin repository](https://github.com/ckan/ckanext-harvest?tab=readme-ov-file#the-ckan-harvester) can be used. However these have not been tested and are not guaranteed
+to work.
+
+
+## SODA
+
+E.g.
+
+```json
+{"app_token": "<TOKEN_HERE>", "remote_orgs": "create"}
+```
+
+
+`remote_orgs`
+
+By default, remote organizations are ignored. Setting this property
+enables the harvester to import remote organizations. Setting it to
+'create' will make an attempt to create the organizations by copying
+the details from the remote CKAN.
+
+`app_token` - All requests should include an app token that identifies
+your application, and each application should have its own unique app
+token. See [Socrata Developer Portal](https://dev.socrata.com/foundry/opendata.camden.gov.uk/uqwb-mdhe/embed)
+
+## Redbridge and NOMIS
+
+None identified


### PR DESCRIPTION
Completes [the story adding support for harvesting private datasets from datapress](https://london.atlassian.net/browse/DAT-688).

Includes previous harvester documentation ([copied from Jira](https://london.atlassian.net/browse/DAT-687?focusedCommentId=188437)) this was mainly added so I can document the new parameters required for the harvester.  

This documentation may be improved in the future.
