### PR TITLE
Feature/785 Check against the mapping list to see if an org should be marked as d…

### DIFF
--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -19,12 +19,22 @@ from ckanext.datapress_harvester.util import (
 )
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject
+import csv
 
 
 log = logging.getLogger(__name__)
 
 EXTRA_PKG_FIELDS = ['london_smallest_geography', 'update_frequency']
 EXTRA_RESOURCE_FIELDS = ['temporal_coverage_from', 'temporal_coverage_to']
+
+ORGAINZATION_DICT = {}
+try:
+    with open("organisation_mappings.csv", mode='r') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]
+except:
+    log.warning("Failed to load CSV")
 
 
 class DataPressHarvester(HarvesterBase):
@@ -635,6 +645,12 @@ class DataPressHarvester(HarvesterBase):
                         log.info("Organization %s is not available", remote_org)
                         if remote_orgs == "create" and "organization" in package_dict:
                             org = package_dict["organization"]
+                            mapped_org_name = ORGAINZATION_DICT.get(org["name"], "")
+                            
+                            if mapped_org_name != "":
+                                org["title"]= mapped_org_name
+                                org["name"]= mapped_org_name
+                            
                             for key in [
                                 "packages",
                                 "created",

--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -27,16 +27,24 @@ log = logging.getLogger(__name__)
 EXTRA_PKG_FIELDS = ['london_smallest_geography', 'update_frequency']
 EXTRA_RESOURCE_FIELDS = ['temporal_coverage_from', 'temporal_coverage_to']
 
-ORGAINZATION_DICT = {}
+PROVIDER_ORG_MAPPINGS = {}
 try:
-    with open("organisation_mappings.csv", mode='r') as csvfile:
+    with open("organisation_mappings.csv", mode='r', encoding='utf-8-sig') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]
-except:
-    log.warning("Failed to load CSV")
+            provider_id = row["Provider"]
+            original_id = row["Original ID"]
+            if provider_id not in PROVIDER_ORG_MAPPINGS:
+                PROVIDER_ORG_MAPPINGS[provider_id] = {}
+            if original_id not in PROVIDER_ORG_MAPPINGS[provider_id]:
+                PROVIDER_ORG_MAPPINGS[provider_id][original_id] = {}
+                
+            PROVIDER_ORG_MAPPINGS[provider_id][original_id]['name'] = row["Override ID"]
+            PROVIDER_ORG_MAPPINGS[provider_id][original_id]['title'] = row["Override Title"]                        
+except BaseException as ex:    
+    log.info(f"No organisation_mappings.csv file was provided to canonicalise organisation names {ex}")
 
-
+    
 class DataPressHarvester(HarvesterBase):
     """
     A Harvester for DataPress instances.
@@ -614,15 +622,15 @@ class DataPressHarvester(HarvesterBase):
                             )
 
                 package_dict["groups"] = validated_groups
-
+            
             # Local harvest source organization
             source_dataset = get_action("package_show")(
                 base_context.copy(), {"id": harvest_object.source.id}
             )
             local_org = source_dataset.get("owner_org")
 
-            remote_orgs = self.config.get("remote_orgs", None)
-
+            remote_orgs = self.config.get("remote_orgs", None)                       
+            
             if remote_orgs not in ("only_local", "create"):
                 # Assign dataset to the source organization
                 package_dict["owner_org"] = local_org
@@ -642,14 +650,16 @@ class DataPressHarvester(HarvesterBase):
                         )
                         validated_org = org["id"]
                     except NotFound:
-                        log.info("Organization %s is not available", remote_org)
+                        log.info("Organization %s is not available", remote_org)                        
                         if remote_orgs == "create" and "organization" in package_dict:
+
+                            source_name = get_action('harvest_source_show')(base_context,{'id':harvest_object.source.id}).get('name')
                             org = package_dict["organization"]
-                            mapped_org_name = ORGAINZATION_DICT.get(org["name"], "")
-                            
-                            if mapped_org_name != "":
-                                org["title"]= mapped_org_name
-                                org["name"]= mapped_org_name
+                            mapped_org = PROVIDER_ORG_MAPPINGS.get(source_name,{}).get(org["name"])
+
+                            if mapped_org:                                
+                                org["title"] = mapped_org.get('title') or mapped_org['name']
+                                org["name"]= mapped_org['name']
                             
                             for key in [
                                 "packages",

--- a/ckanext/datapress_harvester/harvesters/soda.py
+++ b/ckanext/datapress_harvester/harvesters/soda.py
@@ -2,22 +2,26 @@ import logging
 import requests
 import hashlib
 import datetime
-
 from ckan import model
 from ckan.lib.helpers import json
 import ckan.plugins.toolkit as tk
-
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject
 from ckan.logic import NotFound 
-
 import csv
 
-with open("organisation_mappings.csv", mode='r') as csvfile:
-    ORGAINZATION_DICT = {}
-    reader = csv.DictReader(csvfile)
-    for row in reader:
-         ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]
+log = logging.getLogger(__name__)
+
+
+
+ORGAINZATION_DICT = {}
+try:
+    with open("organisation_mappings.csv", mode='r') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]
+except:
+    log.warning("Failed to load CSV")
 
 from ckanext.datapress_harvester.util import (
     get_package_extra_val,
@@ -28,7 +32,6 @@ from ckanext.datapress_harvester.util import (
     add_default_extras,
     add_existing_extras
 )
-log = logging.getLogger(__name__)
 
 # In ckan, we should be able to add a license list such as
 # https://licenses.opendefinition.org/licenses/groups/all.json by setting the ckan.licenses_group_url field in the config, but that doesn't seem to be
@@ -235,6 +238,7 @@ class SODAHarvester(HarvesterBase):
         return True
 
     def _maybe_create_organisation(self, base_context, org_name, org_link):
+
         org_id = sanitise(org_name)
 
         mapped_org_id = ORGAINZATION_DICT.get(org_id, org_id)

--- a/ckanext/datapress_harvester/harvesters/soda.py
+++ b/ckanext/datapress_harvester/harvesters/soda.py
@@ -11,6 +11,14 @@ from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject
 from ckan.logic import NotFound 
 
+import csv
+
+with open("organisation_mappings.csv", mode='r') as csvfile:
+    ORGAINZATION_DICT = {}
+    reader = csv.DictReader(csvfile)
+    for row in reader:
+         ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]
+
 from ckanext.datapress_harvester.util import (
     get_package_extra_val,
     upsert_package_extra,
@@ -228,8 +236,11 @@ class SODAHarvester(HarvesterBase):
 
     def _maybe_create_organisation(self, base_context, org_name, org_link):
         org_id = sanitise(org_name)
+
+        mapped_org_id = ORGAINZATION_DICT.get(org_id, org_id)
+
         try:
-            data_dict = {"id": org_id}
+            data_dict = {"id": mapped_org_id}
             org = tk.get_action("organization_show")(
                 base_context.copy(), data_dict
             )


### PR DESCRIPTION
Update datapress harvester to support canonicalisation of organisation ids through an `organisation_mappings.csv` file.

The file is included in the upstream repository.

Though its structure is like this; cells are identified by their column IDs.

| Provider | Original ID | Override ID | Override Title |
|--------|--------|--------|--------|
| `brent` | `office-for-national-statistics` | `ons` | Office for National Statistics |
