### PR TITLE
DAT-781 temporal coverage

### DIFF
--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -301,17 +301,19 @@ class DataPressHarvester(HarvesterBase):
         response.raise_for_status()
         response_dict = response.json()
 
-        return {
-            item["id"]: {
-                k: v
-                for k, v in {
-                    "london_smallest_geography": item.get("london_smallest_geography"),
-                    "update_frequency": item.get("update_frequency"),
-                }.items()
-                if v
-            }
-            for item in response_dict
-        }
+        lookup = {}
+
+        extra_pkg_fields = ['london_smallest_geography', 'update_frequency']
+
+        for package_dict in response_dict:
+            pkg_id = package_dict['id']
+            pkg_extra_fields = {}
+            for field in extra_pkg_fields:
+                if field in package_dict and package_dict[field] != '':
+                    pkg_extra_fields[field] = package_dict[field]
+                    lookup[pkg_id] = pkg_extra_fields
+
+        return lookup
 
     def _fetch_packages(self, remote_datapress_base_url):
         """Fetch the current package list from DataPress"""

--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -401,13 +401,11 @@ class DataPressHarvester(HarvesterBase):
             if package_dict[key] is None:
                 del package_dict[key]
 
-        # Tags must be alphanumeric
-        for i, tag in enumerate(package_dict["tags"]):
-            #breakpoint()
-            # NOTE THIS RAISES AN EXCEPTION FORMAT should be {'tags': [{'name': 'tagname'}]}
-            package_dict["tags"][i]["name"] = re.sub(
-                "[^a-zA-Z0-9 \-_.]", "", tag["name"]
-            )
+        def fixup_tag(tag):
+            new_tag = re.sub("[^a-zA-Z0-9 \-_.]", "", tag)
+            return {'name': new_tag}
+
+        package_dict["tags"] = list(map(fixup_tag, package_dict["tags"]))
 
         # Some emails need cleaning up. (I think CKAN is actually too strict
         # here, and rejects valid emails. You're allowed some pretty weird

--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -216,7 +216,7 @@ class DataPressHarvester(HarvesterBase):
         try:
             pkg_dicts = self._fetch_packages(remote_datapress_base_url)
         except ContentFetchError as e:
-            log.info("Fetching datasets gave an error: %s", e)
+            log.exception("Fetching datasets gave an error")
             self._save_gather_error(
                 "Unable to fetch datasets from DataPress:%s url:%s"
                 % (e, remote_datapress_base_url),
@@ -289,6 +289,7 @@ class DataPressHarvester(HarvesterBase):
 
             return object_ids
         except Exception as e:
+            log.exception("Exception during gather_stage")
             self._save_gather_error("%r" % e.message, harvest_job)
 
     def _fetch_datapress_extra_fields(self, remote_datapress_base_url, request_headers):
@@ -386,6 +387,8 @@ class DataPressHarvester(HarvesterBase):
 
         # Tags must be alphanumeric
         for i, tag in enumerate(package_dict["tags"]):
+            #breakpoint()
+            # NOTE THIS RAISES AN EXCEPTION FORMAT should be {'tags': [{'name': 'tagname'}]}
             package_dict["tags"][i]["name"] = re.sub(
                 "[^a-zA-Z0-9 \-_.]", "", tag["name"]
             )
@@ -728,6 +731,8 @@ class DataPressHarvester(HarvesterBase):
 
             return result
         except ValidationError as e:
+            log.exception("ValidationError during Import")
+
             self._save_object_error(
                 "Invalid package with GUID %s: %r"
                 % (harvest_object.guid, e.error_dict),
@@ -735,6 +740,7 @@ class DataPressHarvester(HarvesterBase):
                 "Import",
             )
         except Exception as e:
+            log.exception("Exception during Import")
             self._save_object_error("%s" % e, harvest_object, "Import")
 
 


### PR DESCRIPTION
Updates to retrieve and store temporal coverage metadata, this also has a dependency on the PR https://github.com/GreaterLondonAuthority/dfl-ckanext/pull/159