### PR TITLE
DAT-1018 redbridge datasets download link not working

### DIFF
--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -22,7 +22,7 @@ from ckanext.datapress_harvester.util import (
 from .mixins import DFLHarvesterMixin
 log = logging.getLogger(__name__)
 
-REDBRIDGE_API_URL = "http://data.redbridge.gov.uk/api/"
+REDBRIDGE_API_URL = "https://data.redbridge.gov.uk/api/"
 
 
 def _generate_resource(package_id, dataset, is_csv):
@@ -31,12 +31,7 @@ def _generate_resource(package_id, dataset, is_csv):
     if is_csv:
         url = url.replace("XML", "CSV")
 
-    sha1 = hashlib.sha1()
-    resource_id = sha1.update(url.encode())
-    resource_id = sha1.hexdigest()
-
     return {
-        "id": resource_id,
         "package_id": package_id,
         "url": url,
         "name": dataset["Title"],
@@ -143,7 +138,7 @@ class RedbridgeHarvester(HarvesterBase, DFLHarvesterMixin):
                     datasets_metadata = [datasets_metadata]
 
                 for d in datasets_metadata:
-                    full_title = f"Redbrige - {schema_title} - {d['Title']}"
+                    full_title = f"Redbridge - {schema_title} - {d['Title']}"
                     sha1 = hashlib.sha1()
                     package_id = sha1.update(full_title.encode())
                     package_id = sha1.hexdigest()

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -28,8 +28,14 @@ REDBRIDGE_API_URL = "https://data.redbridge.gov.uk/api/"
 def _generate_resource(package_id, dataset, is_csv):
     """Generate a resource dict for use in a package_dict"""
     url = dataset["FriendlyUrl"]
+
+    # the api specifies http - a direct download gets blocked as insecure on chrome and edge in certain hosting setups
+    if url.startswith("http://"):
+        url = url.replace("http://", "https://")
+
     if is_csv:
         url = url.replace("XML", "CSV")
+
 
     return {
         "package_id": package_id,


### PR DESCRIPTION
https://london.atlassian.net/browse/DAT-1018

Simple string edit to always ensure https urls, since the redbridge api provides its links as http

Local testing also revealed duplicate resource ids when generating resources based on the url, so removes this generation to allow ckan to handle it automatically