### PR TITLE
Dat 998 unified api download link not working

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/tflunified.py
+++ b/ckanext/datapress_harvester/harvesters2/tflunified.py
@@ -54,7 +54,7 @@ class TflCollect(Collector[dict[str, Any]]):
                 # )
 
         operations.insert(0, response_details['info']['description'])
-        description = "\n".join(operations)
+        description = "<p>".join(operations)
 
         resources =[{
                         "name": f"TfL Unified API",

--- a/ckanext/datapress_harvester/harvesters2/tflunified.py
+++ b/ckanext/datapress_harvester/harvesters2/tflunified.py
@@ -7,10 +7,12 @@ from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvest
 
 class TflCollect(Collector[dict[str, Any]]):
 
-    def gather(self, api_version: str = "2022-04-01-preview") -> list[str]:
+    api_version = "2022-04-01-preview"
+
+    def gather(self) -> list[str]:
 
         apis_url = "https://api-portal.tfl.gov.uk/developer/apis"
-        params = {"api-version": api_version}
+        params = {"api-version": self.api_version}
 
         api_details = requests.get(apis_url, params=params).json()["value"]
 
@@ -18,10 +20,10 @@ class TflCollect(Collector[dict[str, Any]]):
 
         return api_urls
 
-    def fetch(self, from_url: str, api_version: str = "2022-04-01-preview") -> dict[str, Any]:
+    def fetch(self, from_url: str) -> dict[str, Any]:
 
         headers = {"Accept": "application/vnd.oai.openapi+json"}  # send nothing for a simpler response
-        params = {"export": "true", "api-version": api_version}
+        params = {"export": "true", "api-version": self.api_version}
 
         api_details = requests.get(from_url, params=params, headers=headers).json()
 
@@ -29,23 +31,42 @@ class TflCollect(Collector[dict[str, Any]]):
 
     def transform(self, response_details: dict[str, Any], upstream_url: str, org_name: str) -> Iterable[SimpleStandard]:
 
+        # get upstream id from url (before including args)
+        upstream_id = upstream_url.split("/")[-1]
+        # include version in upstream url
+        upstream_url = f"{upstream_url}?api-version={self.api_version}"
+
         # include path descriptions
-        # todo how do we actually want to represent this? Resources won't show in search and it looks a bit silly
         operations = []
+
         for path, path_details in response_details["paths"].items():
             for method, method_details in path_details.items():
-                # operations.append(f"{method.upper()} {path}: {method_details['description']}")
-                operations.append(
-                    {"name": method_details['description'],
-                     "description": f"{method.upper()} {path}"}
-                )
+                operations.append(f"{method.upper()} {path}: {method_details['description']}")
+                # currently not listing as resources since those descriptions don't show in search
+                # operations.append(
+                #     {
+                #         "name": f"{method.upper()} {path}".encode(),
+                #         "description": f"{method_details['description']}".encode(),
+                #         "url": f"https://api-portal.tfl.gov.uk/api-details#"
+                #                f"api={upstream_id}"
+                #                f"&operation={method_details['operationId']}"
+                #     }
+                # )
+
+        operations.insert(0, response_details['info']['description'])
+        description = "\n".join(operations)
+
+        resources =[{
+                        "name": f"TfL Unified API",
+                        "url": f"https://api-portal.tfl.gov.uk/api-details#api={upstream_id}"
+                    }]
 
         yield SimpleStandard(
             package_id=SimpleStandard.create_hashed_id(upstream_url + response_details["info"]["title"]),
             title=f"TfL Unified API - {response_details['info']['title']}",
-            description=response_details['info']['description'],
+            description=description,
             upstream_url=upstream_url,
-            resources=operations,
+            resources=resources,
             org_name=org_name
         )
 


### PR DESCRIPTION
https://london.atlassian.net/browse/DAT-998

- Switches direct download for a link to the portal - since there can be arguments required it doesn't make sense to send users to a link that they need to edit
- Includes api route descriptions in the main description
- Fixes upstream url to include args