### PR TITLE
DAT-1019 Datasets that are harvested but don't show as being harvested

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/fingertips.py
+++ b/ckanext/datapress_harvester/harvesters2/fingertips.py
@@ -6,54 +6,49 @@ from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleS
 from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
 
 
-class FingertipsCollect(Collector[dict[str, Any]]):
+class FingertipsCollect(Collector[dict[str, Any], dict[str, Any]]):
 
-    def gather(self) -> list[str]:
+    catalogue_url = "https://fingertips.phe.org.uk/api/indicator_metadata/all?include_definition=yes&include_system_content=yes"
+
+    def gather(self) -> list[dict[str, Any]]:
         # fingertips api gives access to metadata for all sources under a single url
-        api_urls = [
-            "https://fingertips.phe.org.uk/api/indicator_metadata/all?include_definition=yes&include_system_content=yes"]
+        all_meta = requests.get(self.catalogue_url).json()
+        return list(all_meta.values())
 
-        return api_urls
+    def fetch(self, from_url: dict[str, Any]) -> dict[str, Any]:
+        return from_url
 
-    def fetch(self, from_url: str) -> dict[str, Any]:
-        return requests.get(from_url).json()
+    def transform(self, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
 
-    def transform(self, sources: dict[str, Any], upstream_url: str, org_name: str) -> Iterable[SimpleStandard]:
-        transformed_sources = []
+        # find the most recent update between "uploaded" and "deleted" dates
+        src_last_updated = None
+        if source_data.get("DataChange"):
+            timestamps = [datetime.strptime(source_data["DataChange"]["LastUploadedAt"], "%Y-%m-%dT%H:%M:%S"),
+                          datetime.strptime(source_data["DataChange"]["LastDeletedAt"], "%Y-%m-%dT%H:%M:%S")]
 
-        for source in sources:
-            source_data = sources[source]
-            # find the most recent update between "uploaded" and "deleted" dates
-            src_last_updated = None
-            if source_data.get("DataChange"):
-                timestamps = [datetime.strptime(source_data["DataChange"]["LastUploadedAt"], "%Y-%m-%dT%H:%M:%S"),
-                              datetime.strptime(source_data["DataChange"]["LastDeletedAt"], "%Y-%m-%dT%H:%M:%S")]
+            src_last_updated = max(
+                timestamps, default=None)
 
-                src_last_updated = max(
-                    timestamps, default=None)
+        source_descriptive = source_data["Descriptive"]
 
-            source_descriptive = source_data["Descriptive"]
-
-            transformed_sources.append(SimpleStandard(
-                package_id=f"fingertips-{source_data.get('IID')}",
-                title=source_descriptive.get("Name"),
-                description=source_descriptive.get(
-                    "Definition"),
-                author=source_descriptive.get("DataSource"),
-                maintainer=source_descriptive.get(
-                    "srcSourceLink"),
-                update_frequency=source_descriptive.get(
-                    "Frequency"),
-                private=False,
-                notes=source_descriptive.get(
-                    "Notes"),
-                # todo: check 'LatestChangeTimestampOverride' response field as alternative
-                data_updated_at=src_last_updated,
-                upstream_url=upstream_url,
-                org_name=org_name
-            ))
-
-        return transformed_sources
+        yield SimpleStandard(
+            package_id=f"fingertips-{source_data.get('IID')}",
+            title=source_descriptive.get("Name"),
+            description=source_descriptive.get(
+                "Definition"),
+            author=source_descriptive.get("DataSource"),
+            maintainer=source_descriptive.get(
+                "srcSourceLink"),
+            update_frequency=source_descriptive.get(
+                "Frequency"),
+            private=False,
+            notes=source_descriptive.get(
+                "Notes"),
+            # todo: check 'LatestChangeTimestampOverride' response field as alternative
+            data_updated_at=src_last_updated,
+            upstream_url=self.catalogue_url,
+            org_name=org_name
+        )
 
 
 class FingertipsHarvester(SimpleHarvester):

--- a/ckanext/datapress_harvester/harvesters2/fingertips.py
+++ b/ckanext/datapress_harvester/harvesters2/fingertips.py
@@ -2,7 +2,7 @@ import requests
 from datetime import datetime
 from typing import Any, Iterable
 
-from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
+from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard, A
 from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
 
 
@@ -14,6 +14,9 @@ class FingertipsCollect(Collector[dict[str, Any], dict[str, Any]]):
         # fingertips api gives access to metadata for all sources under a single url
         all_meta = requests.get(self.catalogue_url).json()
         return list(all_meta.values())
+
+    def gather_identifier(self, source_data: dict[str, Any]) -> str:
+        return f"{self.catalogue_url}{source_data['IID']}"
 
     def fetch(self, from_url: dict[str, Any]) -> dict[str, Any]:
         return from_url

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -35,9 +35,9 @@ class SimpleHarvester(HarvesterBase):
 
             for item in gathered_items:
 
-                # expects that the result of Collector.gather() is an appropriate guid & json serializable
-                identifier = json.dumps(item)
+                identifier = self.collector().gather_identifier(item)
 
+                # should hashing happen in the collector?
                 obj = HarvestObject(guid=SimpleStandard.create_hashed_id(identifier),
                                     job=harvest_job,
                                     content=item)

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -18,7 +18,7 @@ class SimpleHarvester(HarvesterBase):
 
     @staticmethod
     @abstractmethod
-    def collector() -> Collector[Any]:
+    def collector() -> Collector[Any, Any]:
         pass
 
     @staticmethod

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -40,7 +40,7 @@ class SimpleHarvester(HarvesterBase):
                 # should hashing happen in the collector?
                 obj = HarvestObject(guid=SimpleStandard.create_hashed_id(identifier),
                                     job=harvest_job,
-                                    content=item)
+                                    content=json.dumps(item))
                 obj.save()
 
 
@@ -64,8 +64,8 @@ class SimpleHarvester(HarvesterBase):
 
         try:
 
-            fetched_content = self.collector().fetch(harvest_object.content)
-            harvest_object.content = fetched_content
+            fetched_content = self.collector().fetch(json.loads(harvest_object.content))
+            harvest_object.content = json.dumps(fetched_content)
 
         except Exception as e:
             # todo set up proper exceptions
@@ -94,7 +94,7 @@ class SimpleHarvester(HarvesterBase):
             )
             harvester_org = harvest_source.get("owner_org")
 
-            for item in self.collector().transform(harvest_object.content, org_name=harvester_org):
+            for item in self.collector().transform(json.loads(harvest_object.content), org_name=harvester_org):
                 package_dict = item.as_dfl_package()
 
                 result = self._create_or_update_package(

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from abc import abstractmethod
 from typing import Any, Dict
@@ -29,16 +30,26 @@ class SimpleHarvester(HarvesterBase):
         try:
             logging.info(f"Gathering {self.info()['name']}")
 
-            all_urls = self.collector().gather()
+            gathered_items = self.collector().gather()
             all_jobs = []
 
-            for url in all_urls:
-                obj = HarvestObject(guid=SimpleStandard.create_hashed_id(url), job=harvest_job, content=url)
+            for item in gathered_items:
+
+                # expects that the result of Collector.gather() is an appropriate guid & json serializable
+                identifier = json.dumps(item)
+
+                obj = HarvestObject(guid=SimpleStandard.create_hashed_id(identifier),
+                                    job=harvest_job,
+                                    content=item)
                 obj.save()
+
+
 
                 all_jobs.append(obj.id)
 
             return all_jobs
+
+            # todo delete datasets that don't exist in gathered items
 
         except Exception as e:
             # todo set up proper exceptions
@@ -48,14 +59,27 @@ class SimpleHarvester(HarvesterBase):
         return []
 
     def fetch_stage(self, harvest_object):
-        # there doesn't seem to be any particular value to separating fetch and import, so don't overcomplicate
+
+        logging.info(f"Fetching {self.info()['name']}")
+
+        try:
+
+            fetched_content = self.collector().fetch(harvest_object.content)
+            harvest_object.content = fetched_content
+
+        except Exception as e:
+            # todo set up proper exceptions
+            # may be useful https://github.com/GSA/data.gov/wiki/Examples-of-Harvest-Job-Errors
+            logging.error(f"Failed to fetch {harvest_object.guid}: {str(e)}")
+            self._save_object_error(f"Couldn't fetch id {harvest_object.guid}, see logs for detail", harvest_object)
+
+            return False
+
         return True
 
     def import_stage(self, harvest_object):
 
         logging.info(f"Importing {self.info()['name']}")
-
-        source_url = harvest_object.content
 
         try:
 
@@ -70,15 +94,7 @@ class SimpleHarvester(HarvesterBase):
             )
             harvester_org = harvest_source.get("owner_org")
 
-            logging.info(f"Fetching url: {source_url}")
-
-            content = self.collector().fetch(source_url)
-
-            logging.info(f"Mapping content from {source_url} into org {harvester_org}")
-
-            for item in self.collector().transform(content,
-                                                   upstream_url=source_url,  # todo, it may be worth including params
-                                                   org_name=harvester_org):
+            for item in self.collector().transform(harvest_object.content, org_name=harvester_org):
                 package_dict = item.as_dfl_package()
 
                 result = self._create_or_update_package(
@@ -87,14 +103,14 @@ class SimpleHarvester(HarvesterBase):
                     package_dict_form="package_show"
                 )
 
-                logging.info(f"Saved {source_url}: {result}")
+                logging.info(f"Saved {item.title}: {result}")
 
             return True
 
         except Exception as e:
             # todo set up proper exceptions
             # may be useful https://github.com/GSA/data.gov/wiki/Examples-of-Harvest-Job-Errors
-            logging.error(f"Importing {source_url} failed: {str(e)}")
-            self._save_object_error(f"Couldn't import {source_url}, see logs for detail", harvest_object)
+            logging.error(f"Failed to import {harvest_object.guid}: {str(e)}")
+            self._save_object_error(f"Couldn't import id {harvest_object.guid}, see logs for detail", harvest_object)
 
         return False

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -114,6 +114,11 @@ class Collector(ABC, Generic[A,B]):
         pass
 
     @abstractmethod
+    def gather_identifier(self, received: A) -> str:
+        # how should a guid be created for each A?
+        pass
+
+    @abstractmethod
     def fetch(self, received: A) -> B:
         # fetch any extra metadata per A in gather()
         pass

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -101,23 +101,24 @@ class SimpleStandard:
         return package
 
 
-# Define child classes w/ e.g. MyClass(Collector[dict]) to enforce T as a dict
-T = TypeVar("T")
+# Define child classes w/ e.g. MyClass(Collector[str, dict]) to enforce first result as str, second result as a dict
+A = TypeVar("A")
+B = TypeVar("B")
 
 
-class Collector(ABC, Generic[T]):
+class Collector(ABC, Generic[A,B]):
 
     @abstractmethod
-    def gather(self) -> Iterable[str]:
-        # gather urls which need to be harvested from
+    def gather(self) -> Iterable[A]:
+        # gather initial items
         pass
 
     @abstractmethod
-    def fetch(self, url: str) -> T:
-        # fetch metadata from required url
+    def fetch(self, received: A) -> B:
+        # fetch any extra metadata per A in gather()
         pass
 
     @abstractmethod
-    def transform(self, received: T, upstream_url: str, org_name: str) -> Iterable[SimpleStandard]:
-        # make any adjustments before import
+    def transform(self, received: B, org_name: str) -> Iterable[SimpleStandard]:
+        # make any adjustments to B received from fetch() and create standardised items
         pass

--- a/ckanext/datapress_harvester/harvesters2/tflunified.py
+++ b/ckanext/datapress_harvester/harvesters2/tflunified.py
@@ -1,7 +1,7 @@
 import requests
 from typing import Any, Iterable
 
-from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
+from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard, A
 from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
 
 
@@ -19,6 +19,9 @@ class TflCollect(Collector[str, dict[str, Any]]):
         api_urls = [f"https://api-portal.tfl.gov.uk/developer/apis/{api['id']}" for api in api_details]
 
         return api_urls
+
+    def gather_identifier(self, from_url: str) -> str:
+        return from_url
 
     def fetch(self, from_url: str) -> dict[str, Any]:
 

--- a/ckanext/datapress_harvester/harvesters2/tflunified.py
+++ b/ckanext/datapress_harvester/harvesters2/tflunified.py
@@ -1,7 +1,7 @@
 import requests
 from typing import Any, Iterable
 
-from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard, A
+from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
 from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
 
 

--- a/ckanext/datapress_harvester/harvesters2/tflunified.py
+++ b/ckanext/datapress_harvester/harvesters2/tflunified.py
@@ -5,7 +5,7 @@ from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleS
 from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
 
 
-class TflCollect(Collector[dict[str, Any]]):
+class TflCollect(Collector[str, dict[str, Any]]):
 
     api_version = "2022-04-01-preview"
 
@@ -27,22 +27,27 @@ class TflCollect(Collector[dict[str, Any]]):
 
         api_details = requests.get(from_url, params=params, headers=headers).json()
 
+        # neither the url nor the internal id are included in the response, so include these to send to next step
+        api_details["upstream_id"] = from_url.split("/")[-1]
+        api_details["upstream_url"] = f"{from_url}?api-version={self.api_version}"
+
         return dict(api_details)
 
-    def transform(self, response_details: dict[str, Any], upstream_url: str, org_name: str) -> Iterable[SimpleStandard]:
+    def transform(self, response_details: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
 
-        # get upstream id from url (before including args)
-        upstream_id = upstream_url.split("/")[-1]
-        # include version in upstream url
-        upstream_url = f"{upstream_url}?api-version={self.api_version}"
+        # Show the tfl portal for the current api as a resource
+        resources = [{
+            "name": f"TfL Unified API",
+            "url": f"https://api-portal.tfl.gov.uk/api-details#api={response_details['upstream_id']}"
+        }]
 
-        # include path descriptions
+        # include path descriptions in main description
         operations = []
 
         for path, path_details in response_details["paths"].items():
             for method, method_details in path_details.items():
                 operations.append(f"{method.upper()} {path}: {method_details['description']}")
-                # currently not listing as resources since those descriptions don't show in search
+                # currently not listing as resources since resources don't show in search & some require args
                 # operations.append(
                 #     {
                 #         "name": f"{method.upper()} {path}".encode(),
@@ -56,16 +61,11 @@ class TflCollect(Collector[dict[str, Any]]):
         operations.insert(0, response_details['info']['description'])
         description = "<p>".join(operations)
 
-        resources =[{
-                        "name": f"TfL Unified API",
-                        "url": f"https://api-portal.tfl.gov.uk/api-details#api={upstream_id}"
-                    }]
-
         yield SimpleStandard(
-            package_id=SimpleStandard.create_hashed_id(upstream_url + response_details["info"]["title"]),
+            package_id=SimpleStandard.create_hashed_id(response_details["upstream_url"] + response_details["info"]["title"]),
             title=f"TfL Unified API - {response_details['info']['title']}",
             description=description,
-            upstream_url=upstream_url,
+            upstream_url=response_details["upstream_url"],
             resources=resources,
             org_name=org_name
         )

--- a/ckanext/datapress_harvester/harvesters2/ukpn.py
+++ b/ckanext/datapress_harvester/harvesters2/ukpn.py
@@ -70,5 +70,3 @@ class UkpnHarvester(SimpleHarvester):
             "title": "UK Power Networks API",
             "description": "Harvests from UK Power Networks API"
         }
-
-UKPNCollect.gather

--- a/ckanext/datapress_harvester/harvesters2/ukpn.py
+++ b/ckanext/datapress_harvester/harvesters2/ukpn.py
@@ -20,42 +20,41 @@ def parse_datetime(timestamp):
             continue
 
 
-class UKPNCollect(Collector[dict[str, Any]]):
+class UKPNCollect(Collector[dict[str, Any], dict[str, Any]]):
 
-    def gather(self) -> list[str]:
+    catalogue_url = "https://ukpowernetworks.opendatasoft.com/api/explore/v2.1/catalog/datasets/"
+
+    def gather(self) -> list[dict[str, Any]]:
         # UKPN api gives access to metadata for all sources under a single url
-        api_urls = [
-            "https://ukpowernetworks.opendatasoft.com/api/explore/v2.1/catalog/datasets/"]
+        all_meta = requests.get(self.catalogue_url).json()
+        meta_results = all_meta.get('results', [])
+        return meta_results
+    
+    def gather_identifier(self, source_data: dict[str, Any]) -> str:
+        return f"{self.catalogue_url}{source_data.get('dataset_uid')}"
 
-        return api_urls
+    def fetch(self, from_url: dict[str, Any]) -> dict[str, Any]:
+        return from_url
 
-    def fetch(self, from_url: str) -> dict[str, Any]:
-        response = requests.get(from_url).json()
-        return response['results']
+    def transform(self, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
 
-    def transform(self, sources: dict[str, Any], upstream_url: str, org_name: str) -> Iterable[SimpleStandard]:
-        transformed_sources = []
-        for source in sources:
-            source_data = source["metas"]
+        source_metas = source_data["metas"]
 
-            print(source_data.get("dublin-core", {}).get("title"),)
-            transformed_sources.append(SimpleStandard(
-                package_id=f"ukpn-{source.get('dataset_uid')}",
-                title=source_data.get("dublin-core", {}).get("title"),
-                description=source_data.get(
-                    "dublin-core", {}).get("description"),
-                update_frequency=source_data.get(
-                    "dublin-core", {}).get("description"),
-                author=source_data.get("dublin-core", {}).get("creator"),
-                org_name=org_name,
-                upstream_url=upstream_url,
-                org_link=source_data.get("dublin-core", {}).get("source"),
-                notes=source_data.get("dublin-core", {}).get("description"),
-                data_updated_at=parse_datetime(
-                    source_data.get("dublin-core", {}).get("modified"))
-            ))
-
-        return transformed_sources
+        yield SimpleStandard(
+            package_id=f"ukpn-{source_data.get('dataset_uid')}",
+            title=source_metas.get("dublin-core", {}).get("title"),
+            description=source_metas.get(
+               "dublin-core", {}).get("description"),
+            update_frequency=source_metas.get(
+                "dublin-core", {}).get("description"),
+            author=source_metas.get("dublin-core", {}).get("creator"),
+            org_name=org_name,
+            upstream_url=self.catalogue_url,
+            org_link=source_metas.get("dublin-core", {}).get("source"),
+            notes=source_metas.get("dublin-core", {}).get("description"),
+            data_updated_at=parse_datetime(
+                source_metas.get("dublin-core", {}).get("modified"))
+        )
 
 
 class UkpnHarvester(SimpleHarvester):
@@ -71,3 +70,5 @@ class UkpnHarvester(SimpleHarvester):
             "title": "UK Power Networks API",
             "description": "Harvests from UK Power Networks API"
         }
+
+UKPNCollect.gather


### PR DESCRIPTION
- Refactors all Collector classes to be able to return anything from gather, not just urls
- Refactors SimpleHarvester to handle this
- Fingertips and UKPN take advantage of these changes to allow them to spread work across jobs
- Also includes ability for Collectors to specify their own GUID at gather: not necessarily required now but futureproofs against any future harvesters that needs distinct IDs and content
