### PR TITLE
Stop using upstream resource IDs

### DIFF
--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -34,18 +34,12 @@ def normalise_ckan_resources(package_dict):
         # So we harmonise them here
         normalised_resources = package_dict.get('organization',{}).get('resources',[])
 
-    def fixup_id(res):
-        input_id = res['id']
-        # CKAN has a validation that ID's must have a minimum length,
-        # but upstream sources have different rules, so pad ids with
-        # 0's if they're shorter than 7 characters
-        res['id'] = input_id.rjust(7,'0')
-        
-        return res
-
-    normalised_resources = list(map(fixup_id, normalised_resources))
 
     for resource in normalised_resources:
+
+        # let our ckan uniquely id resources by not providing the upstream id
+        resource.pop("id")
+
         created = resource.pop('created',None)
         if created:
             resource['upstream_created_at'] = created


### PR DESCRIPTION
Different datapress versions have slightly different ID requirements that don't always fit with ours

This removes the padding of datapress harvester IDs and allows ckan to create new resource ids instead, so there won't be conflict errors

On Brent and Barnet (and presumably future datapress sources too) this is especially important because they organise their resources at the organisation level rather than the dataset level. That makes sense since it means datasets in the same org can share the same resource without duplicating, but the library isn't set up to do that - so there are _always_ "resource exists" errors when two harvested datasets in the same upstream org point to the same file

Ideally we can perform something similar for our own efficiency too - but that involves going through some of the tech debt for these legacy harvesters so isn't addressed here
