### PR TITLE
DL-277-decoupling-refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # ckanext-datapress_harvester
 
+Data for London harvesters are to be migrated away from the CKAN Harvest Extension
+
+New harvesters should create a Collector in harvesters2/ - see directory for readme and examples
+
+Those in harvesters/ are tangled with the CKAN extension and, although still in use, are to be deprecated
+
+
+# Legacy README
+
 This repository provides the following four harvester implementations
 used by the Data for London site to fetch data from upstream data
 sources:

--- a/ckanext/datapress_harvester/harvesters/datapress.py
+++ b/ckanext/datapress_harvester/harvesters/datapress.py
@@ -20,6 +20,15 @@ from ckanext.datapress_harvester.util import (
 from ckanext.harvest.harvesters import HarvesterBase
 from .mixins import DFLHarvesterMixin
 from ckanext.harvest.model import HarvestObject
+
+"""
+Harvesters are intended to be migrated away from the CKAN harvest extension
+
+This harvester is to be deprecated
+
+If you are creating a new harvester you should create a Collector - see harvesters2/
+"""
+
 log = logging.getLogger(__name__)
 
 EXTRA_PKG_FIELDS = ['london_smallest_geography', 'update_frequency']

--- a/ckanext/datapress_harvester/harvesters/nomis_localauthprofile.py
+++ b/ckanext/datapress_harvester/harvesters/nomis_localauthprofile.py
@@ -24,6 +24,14 @@ from ckanext.datapress_harvester.util import (
     add_existing_extras,
 )
 
+"""
+Harvesters are intended to be migrated away from the CKAN harvest extension
+
+This harvester is to be deprecated
+
+If you are creating a new harvester you should create a Collector - see harvesters2/
+"""
+
 log = logging.getLogger(__name__)
 
 

--- a/ckanext/datapress_harvester/harvesters/redbridge.py
+++ b/ckanext/datapress_harvester/harvesters/redbridge.py
@@ -20,6 +20,15 @@ from ckanext.datapress_harvester.util import (
     add_existing_extras,
 )
 from .mixins import DFLHarvesterMixin
+
+"""
+Harvesters are intended to be migrated away from the CKAN harvest extension
+
+This harvester is to be deprecated
+
+If you are creating a new harvester you should create a Collector - see harvesters2/
+"""
+
 log = logging.getLogger(__name__)
 
 REDBRIDGE_API_URL = "https://data.redbridge.gov.uk/api/"

--- a/ckanext/datapress_harvester/harvesters/soda.py
+++ b/ckanext/datapress_harvester/harvesters/soda.py
@@ -20,6 +20,14 @@ from ckanext.datapress_harvester.util import (
     add_existing_extras
 )
 
+"""
+Harvesters are intended to be migrated away from the CKAN harvest extension
+
+This harvester is to be deprecated
+
+If you are creating a new harvester you should create a Collector - see harvesters2/
+"""
+
 log = logging.getLogger(__name__)
 
 # In ckan, we should be able to add a license list such as

--- a/ckanext/datapress_harvester/harvesters2/fingertips.py
+++ b/ckanext/datapress_harvester/harvesters2/fingertips.py
@@ -2,26 +2,29 @@ import requests
 from datetime import datetime
 from typing import Any, Iterable
 
-from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard, A
-from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
+from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
 
 
 class FingertipsCollect(Collector[dict[str, Any], dict[str, Any]]):
 
     catalogue_url = "https://fingertips.phe.org.uk/api/indicator_metadata/all?include_definition=yes&include_system_content=yes"
 
-    def gather(self) -> list[dict[str, Any]]:
+    @classmethod
+    def gather(cls) -> list[dict[str, Any]]:
         # fingertips api gives access to metadata for all sources under a single url
-        all_meta = requests.get(self.catalogue_url).json()
+        all_meta = requests.get(cls.catalogue_url).json()
         return list(all_meta.values())
 
-    def gather_identifier(self, source_data: dict[str, Any]) -> str:
-        return f"{self.catalogue_url}{source_data['IID']}"
+    @ classmethod
+    def gather_identifier(cls, source_data: dict[str, Any]) -> str:
+        return f"{cls.catalogue_url}{source_data['IID']}"
 
-    def fetch(self, from_url: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def fetch(cls, from_url: dict[str, Any]) -> dict[str, Any]:
         return from_url
 
-    def transform(self, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+    @classmethod
+    def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
 
         # find the most recent update between "uploaded" and "deleted" dates
         src_last_updated = None
@@ -49,21 +52,6 @@ class FingertipsCollect(Collector[dict[str, Any], dict[str, Any]]):
                 "Notes"),
             # todo: check 'LatestChangeTimestampOverride' response field as alternative
             data_updated_at=src_last_updated,
-            upstream_url=self.catalogue_url,
+            upstream_url=cls.catalogue_url,
             org_name=org_name
         )
-
-
-class FingertipsHarvester(SimpleHarvester):
-
-    @staticmethod
-    def collector():
-        return FingertipsCollect()
-
-    @staticmethod
-    def info():
-        return {
-            "name": "fingertips",
-            "title": "Public Health Data API",
-            "description": "Harvests from Public Health Data Fingertips API"
-        }

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import Any, Dict
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
+from ckanext.datapress_harvester.harvesters2 import fingertips,tflunified, ukpn
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
@@ -13,6 +14,28 @@ import ckan.plugins.toolkit as toolkit
 
 logging = logging.getLogger(__name__)
 
+
+"""
+SimpleHarvester provides a generalised harvester that runs a Collector
+
+If your source needs extra behaviour, it's preferable to improve SimpleHarvester rather than create many bespoke ones!
+
+Example linking to your collector:
+
+class FingertipsHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector() -> fingertips.FingertipsCollect:
+        return fingertips.FingertipsCollect()
+
+    @staticmethod
+    def info():
+        return {
+            "name": "fingertips",
+            "title": "Public Health Data API",
+            "description": "Harvests from Public Health Data Fingertips API"
+        }
+"""
 
 class SimpleHarvester(HarvesterBase):
 
@@ -34,7 +57,6 @@ class SimpleHarvester(HarvesterBase):
             all_jobs = []
 
             for item in gathered_items:
-
                 identifier = self.collector().gather_identifier(item)
 
                 # should hashing happen in the collector?
@@ -42,8 +64,6 @@ class SimpleHarvester(HarvesterBase):
                                     job=harvest_job,
                                     content=json.dumps(item))
                 obj.save()
-
-
 
                 all_jobs.append(obj.id)
 
@@ -114,3 +134,48 @@ class SimpleHarvester(HarvesterBase):
             self._save_object_error(f"Couldn't import id {harvest_object.guid}, see logs for detail", harvest_object)
 
         return False
+
+
+class FingertipsHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector():
+        return fingertips.FingertipsCollect()
+
+    @staticmethod
+    def info():
+        return {
+            "name": "fingertips",
+            "title": "Public Health Data API",
+            "description": "Harvests from Public Health Data Fingertips API"
+        }
+
+
+class TflUnifiedHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector():
+        return tflunified.TflCollect()
+
+    @staticmethod
+    def info() -> dict[str, str]:
+        return {
+            "name": "tfl-unified",
+            "title": "TfL Unified API",
+            "description": "Harvests from TfL's Unified API"
+        }
+
+
+class UkpnHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector():
+        return ukpn.UKPNCollect()
+
+    @staticmethod
+    def info():
+        return {
+            "name": "ukpn",
+            "title": "UK Power Networks API",
+            "description": "Harvests from UK Power Networks API"
+        }

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -108,22 +108,32 @@ B = TypeVar("B")
 
 class Collector(ABC, Generic[A,B]):
 
+    """Collectors form the basis of a pipeline, results of each step being passed to the next
+
+    The class exists in order to use ABC and enforce the pattern
+    It's important to remember steps may be run independently in pipelines in future - hence classmethod
+    """
+
+    @classmethod
     @abstractmethod
-    def gather(self) -> Iterable[A]:
+    def gather(cls) -> Iterable[A]:
         # gather initial items
         pass
 
+    @classmethod
     @abstractmethod
-    def gather_identifier(self, received: A) -> str:
+    def gather_identifier(cls, received: A) -> str:
         # how should a guid be created for each A?
         pass
 
+    @classmethod
     @abstractmethod
-    def fetch(self, received: A) -> B:
+    def fetch(cls, received: A) -> B:
         # fetch any extra metadata per A in gather()
         pass
 
+    @classmethod
     @abstractmethod
-    def transform(self, received: B, org_name: str) -> Iterable[SimpleStandard]:
+    def transform(cls, received: B, org_name: str) -> Iterable[SimpleStandard]:
         # make any adjustments to B received from fetch() and create standardised items
         pass

--- a/ckanext/datapress_harvester/harvesters2/readme.md
+++ b/ckanext/datapress_harvester/harvesters2/readme.md
@@ -1,16 +1,40 @@
 # Creating a New Harvester
-1. **Collectors should not have any dependencies on the harvesting extension**
-2. Implement the abstract class Collector
-    - Include the return type of what you're passing from fetch() to transform() in the class definition
-    - Gather() returns the urls to fetch from
-    - For each url from gather(), fetch() retrieves its content and returns the details
-    - For each item of content from fetch(), transform() will be called, which should map the original content to the appropriate fields in a common format
-3. Create a Harvester class
-    - If your collector matches the abstract class then you shouldn't need to implement any behaviour
-    - Override collector() to return an instance of the one you created
-    - Override info() to return the dict of information that the harvesting extension requires
-    - If your source is unusual somehow then you may need to override one or more of the harvesting stages
-    - Ideally expand & improve the generic one to handle more cases rather than creating lots of harvesters
-4. Update the entrypoints in setup.py to point to your new harvester class
-5. Add the name you gave in setup.py to the list of extensions in your ckan config (for dev instances this may be in your .env file)
+
+## Create a Collector
+
+**Collectors should not have any dependencies on the harvesting extension**
+
+1. Implement the abstract class Collector
+    - gather() returns the urls to fetch from
+    - For each item from gather(), gather_identifier() specifies how to id the item
+    - For each url from gather(), fetch() retrieves content and returns details
+    - For each item of content from fetch(), transform() will be called, 
+    - transform() should map the original content to a common format (see class SimpleStandard)
+   
+2. Ideally perform mypy type checking on your collector before merge
+   - To type a Collector, include the return types of your steps in the class definition
+     - eg if gather() -> str, fetch() -> dict then your definition could be MyCollector(str, dict)
+
+Collectors are run as a pipeline, the result of each step being passed to the next step as:
+```
+.
+└── gather()
+    ├── gather_identifier()
+    └── fetch()
+        └── transform()
+```
+## Add Collector to CKAN Harvest Extension
+
+**The following steps utilise the harvest extension, likely to be removed for a more scalable pipeline tool**
+
+1. Create a Harvester 
+   - Extend class SimpleHarvester
+   - Override collector() to return an instance of the Collector created in the steps above
+   - Override info() to return the dict of information that the harvesting extension requires
+   - **If unavoidable, ideally add to the behaviour of SimpleHarvester rather than create lots of new classes**
+   
+2. Update the entrypoints in setup.py to point to your new harvester class
+
+3. Add the name you gave in setup.py to the list of extensions in your ckan config 
+   - depending on the environment this may be CKAN__PLUGINS in your .env file
 

--- a/ckanext/datapress_harvester/harvesters2/tflunified.py
+++ b/ckanext/datapress_harvester/harvesters2/tflunified.py
@@ -2,17 +2,17 @@ import requests
 from typing import Any, Iterable
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
-from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
 
 
 class TflCollect(Collector[str, dict[str, Any]]):
 
     api_version = "2022-04-01-preview"
 
-    def gather(self) -> list[str]:
+    @classmethod
+    def gather(cls) -> list[str]:
 
         apis_url = "https://api-portal.tfl.gov.uk/developer/apis"
-        params = {"api-version": self.api_version}
+        params = {"api-version": cls.api_version}
 
         api_details = requests.get(apis_url, params=params).json()["value"]
 
@@ -20,23 +20,26 @@ class TflCollect(Collector[str, dict[str, Any]]):
 
         return api_urls
 
-    def gather_identifier(self, from_url: str) -> str:
+    @classmethod
+    def gather_identifier(cls, from_url: str) -> str:
         return from_url
 
-    def fetch(self, from_url: str) -> dict[str, Any]:
+    @classmethod
+    def fetch(cls, from_url: str) -> dict[str, Any]:
 
         headers = {"Accept": "application/vnd.oai.openapi+json"}  # send nothing for a simpler response
-        params = {"export": "true", "api-version": self.api_version}
+        params = {"export": "true", "api-version": cls.api_version}
 
         api_details = requests.get(from_url, params=params, headers=headers).json()
 
         # neither the url nor the internal id are included in the response, so include these to send to next step
         api_details["upstream_id"] = from_url.split("/")[-1]
-        api_details["upstream_url"] = f"{from_url}?api-version={self.api_version}"
+        api_details["upstream_url"] = f"{from_url}?api-version={cls.api_version}"
 
         return dict(api_details)
 
-    def transform(self, response_details: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+    @classmethod
+    def transform(cls, response_details: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
 
         # Show the tfl portal for the current api as a resource
         resources = [{
@@ -74,16 +77,3 @@ class TflCollect(Collector[str, dict[str, Any]]):
         )
 
 
-class TflUnifiedHarvester(SimpleHarvester):
-
-    @staticmethod
-    def collector() -> TflCollect:
-        return TflCollect()
-
-    @staticmethod
-    def info() -> dict[str, str]:
-        return {
-            "name": "tfl-unified",
-            "title": "TfL Unified API",
-            "description": "Harvests from TfL's Unified API"
-        }

--- a/ckanext/datapress_harvester/harvesters2/ukpn.py
+++ b/ckanext/datapress_harvester/harvesters2/ukpn.py
@@ -3,8 +3,6 @@ from datetime import datetime
 from typing import Any, Iterable
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
-from ckanext.datapress_harvester.harvesters2.lib.harvesters import SimpleHarvester
-
 
 def parse_datetime(timestamp):
     # Function to handle different date formats received in API response
@@ -24,18 +22,19 @@ class UKPNCollect(Collector[dict[str, Any], dict[str, Any]]):
 
     catalogue_url = "https://ukpowernetworks.opendatasoft.com/api/explore/v2.1/catalog/datasets/"
 
-    def gather(self) -> list[dict[str, Any]]:
+    @classmethod
+    def gather(cls) -> list[dict[str, Any]]:
         """UKPN api gives access to metadata for all sources under a single url with pagination"""
-        all_metas = []
+        all_metas: list[dict] = []
         offset = 0
         limit = 100  # Maximum 100 allowed per request
 
-        response = requests.get(self.catalogue_url).json()
+        response = requests.get(cls.catalogue_url).json()
         available_metas = response.get('total_count', 0)
         
         while len(all_metas) < available_metas:
             # Construct URL with pagination parameters
-            paginated_url = f"{self.catalogue_url}?limit={limit}&offset={offset}&include_links=true"
+            paginated_url = f"{cls.catalogue_url}?limit={limit}&offset={offset}&include_links=true"
             
             batch_response = requests.get(paginated_url).json()
             batch_results = batch_response.get('results', [])
@@ -51,14 +50,17 @@ class UKPNCollect(Collector[dict[str, Any], dict[str, Any]]):
                 break
         
         return all_metas
-    
-    def gather_identifier(self, source_data: dict[str, Any]) -> str:
-        return f"{self.catalogue_url}{source_data.get('dataset_uid')}"
 
-    def fetch(self, from_url: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def gather_identifier(cls, source_data: dict[str, Any]) -> str:
+        return f"{cls.catalogue_url}{source_data.get('dataset_uid')}"
+
+    @classmethod
+    def fetch(cls, from_url: dict[str, Any]) -> dict[str, Any]:
         return from_url
 
-    def transform(self, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+    @classmethod
+    def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
 
         source_metas = source_data["metas"]
 
@@ -71,24 +73,9 @@ class UKPNCollect(Collector[dict[str, Any], dict[str, Any]]):
                 "dublin-core", {}).get("description"),
             author=source_metas.get("dublin-core", {}).get("creator"),
             org_name=org_name,
-            upstream_url=self.catalogue_url,
+            upstream_url=cls.catalogue_url,
             org_link=source_metas.get("dublin-core", {}).get("source"),
             notes=source_metas.get("dublin-core", {}).get("description"),
             data_updated_at=parse_datetime(
                 source_metas.get("dublin-core", {}).get("modified"))
         )
-
-
-class UkpnHarvester(SimpleHarvester):
-
-    @staticmethod
-    def collector():
-        return UKPNCollect()
-
-    @staticmethod
-    def info():
-        return {
-            "name": "ukpn",
-            "title": "UK Power Networks API",
-            "description": "Harvests from UK Power Networks API"
-        }

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ setup(
         nomis_localauthprofile=ckanext.datapress_harvester.harvesters:NomisLocalAuthorityProfileScraper
         redbridge_harvester=ckanext.datapress_harvester.harvesters:RedbridgeHarvester
         soda_harvester=ckanext.datapress_harvester.harvesters:SODAHarvester
-        tflunified_harvester=ckanext.datapress_harvester.harvesters2.tflunified:TflUnifiedHarvester
-        ukpn_harvester=ckanext.datapress_harvester.harvesters2.ukpn:UkpnHarvester
-        fingertips_harvester=ckanext.datapress_harvester.harvesters2.fingertips:FingertipsHarvester
+        tflunified_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:TflUnifiedHarvester
+        ukpn_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:UkpnHarvester
+        fingertips_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:FingertipsHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel


### PR DESCRIPTION
- Moves anything in harvesters2/ depending on the harvester extension into lib.harvesters
- Points ckan setup.py to the new location
- Updates readme
- Updates comments on harvesters/ 
- Makes Collector methods classmethods to enforce atomic 'pipeline' steps, even if they're not pipelines yet