### PR TITLE
DL-122 tfl open data

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Any, Dict
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
-from ckanext.datapress_harvester.harvesters2 import fingertips,tflunified, ukpn
+from ckanext.datapress_harvester.harvesters2 import fingertips, tflunified, ukpn, tflopen
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
@@ -178,4 +178,19 @@ class UkpnHarvester(SimpleHarvester):
             "name": "ukpn",
             "title": "UK Power Networks API",
             "description": "Harvests from UK Power Networks API"
+        }
+
+
+class TflOpenHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector() -> tflopen.TflOpenCollect:
+        return tflopen.TflOpenCollect()
+
+    @staticmethod
+    def info() -> dict[str, str]:
+        return {
+            "name": "tfl-open-data",
+            "title": "TfL Open Data",
+            "description": "Harvests from TfL's Open Data Summary page"
         }

--- a/ckanext/datapress_harvester/harvesters2/tflopen.py
+++ b/ckanext/datapress_harvester/harvesters2/tflopen.py
@@ -1,0 +1,77 @@
+import requests
+from typing import Any, Iterable, Generator
+
+from bs4 import BeautifulSoup
+
+from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
+
+
+class TflOpenCollect(Collector[str, dict[str, Any]]):
+    source_page_url = "https://tfl.gov.uk/info-for/open-data-users/our-open-data"
+
+    @classmethod
+    def gather(cls) -> Generator[dict, None, None]:
+        content = requests.get(cls.source_page_url).text
+        soup = BeautifulSoup(content, "html.parser")
+
+        # horrible parsing is simpler here but may be better done in fetch rather than gather if errors start showing
+
+        # text from main page
+        paras = soup.find_all("p")
+        common = str(paras[0])  # + str(paras[4])
+
+        # syndication guidelines pdf
+        guidelines = soup.find("div", class_="multi-document-download-container")
+        # how reliable are links? can we url_parse?
+        guidelines_link = "https://tfl.gov.uk" + guidelines.find("a").get("href")
+        guidelines_text = guidelines.find("div", class_="document-download-text").find("p").text
+        guidelines_attach = guidelines.find("div", class_="document-download-attachment").find("p").text.strip()
+        guidelines_desc = str(paras[3])
+
+        # dataset per api
+        sets = soup.find_all("div", class_="expandable-box")
+
+        for s in sets:
+            heading = s.find("div", class_="accordion-heading").decode_contents()
+            content = s.find("div", class_="start-hidden").decode_contents()
+
+            yield {
+                "heading": heading,
+                "content": content,
+                "guidelines_link": guidelines_link,
+                "guidelines_text": guidelines_text,
+                "guidelines_attach": guidelines_attach,
+                "guidelines_desc": guidelines_desc,
+                "common": common
+            }
+
+    @classmethod
+    def gather_identifier(cls, source_data: dict) -> str:
+        return cls.source_page_url + source_data["heading"]
+
+    @classmethod
+    def fetch(cls, source_data: dict) -> dict[str, Any]:
+        return source_data
+
+    @classmethod
+    def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+        # guidelines link in description so it all shows in search but may be better as a resource
+        guidelines = (f"""
+                      <h3>Guidelines</h3>
+                      <p>
+                        <a href={source_data['guidelines_link']}>
+                          {source_data['guidelines_text']} ({source_data['guidelines_attach']})
+                        </a>
+                      </p>
+                        {source_data['guidelines_desc']}
+                      """)
+
+        description = source_data["content"] + guidelines + source_data["common"]
+
+        yield SimpleStandard(
+            package_id=SimpleStandard.create_hashed_id(cls.gather_identifier(source_data)),
+            title=source_data["heading"],
+            upstream_url=cls.source_page_url,
+            description=description,
+            org_name=org_name
+        )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         tflunified_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:TflUnifiedHarvester
         ukpn_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:UkpnHarvester
         fingertips_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:FingertipsHarvester
+        tflopen_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:TflOpenHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel


### PR DESCRIPTION
Adds first version of new harvester for https://tfl.gov.uk/info-for/open-data-users/our-open-data

Could use neater typing and possibly adjusting where things are done in the pipeline - currently gather() does all of the html parsing since there's only one page source

Includes new collector TflOpenCollector and a SimpleHarvester TflOpenHarvester, linked via setup.py