### PR TITLE
DL-271 remove datasets no longer upstream

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/fingertips.py
+++ b/ckanext/datapress_harvester/harvesters2/fingertips.py
@@ -6,7 +6,7 @@ from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleS
 
 
 class FingertipsCollect(Collector[dict[str, Any], dict[str, Any]]):
-
+    clean_missing_upstream = True
     catalogue_url = "https://fingertips.phe.org.uk/api/indicator_metadata/all?include_definition=yes&include_system_content=yes"
 
     @classmethod

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -37,6 +37,33 @@ class FingertipsHarvester(SimpleHarvester):
         }
 """
 
+# yoinked from harvesters v1, could be refactored
+def harvester_search_dict(source_id, page, limit):
+    return {
+        "fq": '+harvest_source_id:"{0}"'.format(source_id),
+        "fl": "id",
+        "rows": limit,
+        "start": (page - 1) * limit,
+    }
+
+# yoinked from harvesters v1, could be refactored
+def get_harvested_dataset_ids(harvest_source_id):
+    context = {"model": model, "session": model.Session}
+    page = 1
+    limit = 1000
+    query_result = toolkit.get_action("package_search")(
+        context,
+        harvester_search_dict(harvest_source_id, page, limit),
+    )
+    datasets = query_result["results"]
+    while len(datasets) < query_result["count"]:
+        page += 1
+        datasets += toolkit.get_action("package_search")(
+            context, harvester_search_dict(harvest_source_id, page, limit)
+        )["results"]
+
+    return {d["id"] for d in datasets}
+
 class SimpleHarvester(HarvesterBase):
 
     @staticmethod
@@ -101,6 +128,10 @@ class SimpleHarvester(HarvesterBase):
 
         logging.info(f"Importing {self.info()['name']}")
 
+        retrieved_packages = set()
+
+        success = False
+
         try:
 
             # object.source.publisher_id is left empty so look it up from the api for no reason:|
@@ -115,6 +146,9 @@ class SimpleHarvester(HarvesterBase):
             harvester_org = harvest_source.get("owner_org")
 
             for item in self.collector().transform(json.loads(harvest_object.content), org_name=harvester_org):
+
+                retrieved_packages.add(item.package_id)
+
                 package_dict = item.as_dfl_package()
 
                 result = self._create_or_update_package(
@@ -125,15 +159,36 @@ class SimpleHarvester(HarvesterBase):
 
                 logging.info(f"Saved {item.title}: {result}")
 
-            return True
+            success = True
 
         except Exception as e:
-            # todo set up proper exceptions
+            # todo set up proper exceptions - except Exception needed to report any problem in _save_object_error()
             # may be useful https://github.com/GSA/data.gov/wiki/Examples-of-Harvest-Job-Errors
             logging.error(f"Failed to import {harvest_object.guid}: {str(e)}")
             self._save_object_error(f"Couldn't import id {harvest_object.guid}, see logs for detail", harvest_object)
 
-        return False
+        else:
+            # only clean up if there were no errors - avoid accidental deletes
+
+            # only clean up if a collector explicitly says it's ok to do so
+            if self.collector().clean_missing_upstream:
+                
+                # todo sort out this nested try
+                try:
+                    harvested_datasets_all = get_harvested_dataset_ids(harvest_object.source.id)
+                    harvested_datasets_stale = harvested_datasets_all - retrieved_packages
+
+                    for stale_id in harvested_datasets_stale:
+                        toolkit.get_action("dataset_purge")(
+                            base_context.copy(), {"id": stale_id}
+                        )
+
+                except Exception as e:
+                    logging.error(f"Failed to remove datasets no longer upstream for {harvest_object.guid}: {str(e)}")
+                    self._save_object_error(f"Successfully imported {harvest_object.guid} but failed to remove datasets no longer upstream, see logs for details",
+                                            harvest_object)
+
+        return success
 
 
 class FingertipsHarvester(SimpleHarvester):

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -114,6 +114,10 @@ class Collector(ABC, Generic[A,B]):
     It's important to remember steps may be run independently in pipelines in future - hence classmethod
     """
 
+    # this var only exists to prevent accidentally deleting datasets for collectors that don't re-import every dataset
+    # a collector must explicitly state that any dataset not retrieved should be deleted
+    clean_missing_upstream = False
+
     @classmethod
     @abstractmethod
     def gather(cls) -> Iterable[A]:

--- a/ckanext/datapress_harvester/harvesters2/tflopen.py
+++ b/ckanext/datapress_harvester/harvesters2/tflopen.py
@@ -7,6 +7,7 @@ from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleS
 
 
 class TflOpenCollect(Collector[dict[str, Any], dict[str, Any]]):
+    clean_missing_upstream = True
     source_page_url = "https://tfl.gov.uk/info-for/open-data-users/our-open-data"
 
     @classmethod

--- a/ckanext/datapress_harvester/harvesters2/tflopen.py
+++ b/ckanext/datapress_harvester/harvesters2/tflopen.py
@@ -6,11 +6,11 @@ from bs4 import BeautifulSoup
 from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
 
 
-class TflOpenCollect(Collector[str, dict[str, Any]]):
+class TflOpenCollect(Collector[dict[str, Any], dict[str, Any]]):
     source_page_url = "https://tfl.gov.uk/info-for/open-data-users/our-open-data"
 
     @classmethod
-    def gather(cls) -> Generator[dict, None, None]:
+    def gather(cls) -> Generator[dict]:
         content = requests.get(cls.source_page_url).text
         soup = BeautifulSoup(content, "html.parser")
 

--- a/ckanext/datapress_harvester/harvesters2/tflunified.py
+++ b/ckanext/datapress_harvester/harvesters2/tflunified.py
@@ -5,7 +5,7 @@ from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleS
 
 
 class TflCollect(Collector[str, dict[str, Any]]):
-
+    clean_missing_upstream = True
     api_version = "2022-04-01-preview"
 
     @classmethod
@@ -75,5 +75,3 @@ class TflCollect(Collector[str, dict[str, Any]]):
             resources=resources,
             org_name=org_name
         )
-
-

--- a/ckanext/datapress_harvester/harvesters2/ukpn.py
+++ b/ckanext/datapress_harvester/harvesters2/ukpn.py
@@ -19,7 +19,7 @@ def parse_datetime(timestamp):
 
 
 class UKPNCollect(Collector[dict[str, Any], dict[str, Any]]):
-
+    clean_missing_upstream = True
     catalogue_url = "https://ukpowernetworks.opendatasoft.com/api/explore/v2.1/catalog/datasets/"
 
     @classmethod


### PR DESCRIPTION
After importing all datasets, establish which datasets were not updated and remove them

Includes a flag that Collector must explicitly set to allow this behaviour - this is so if any collector retrieves metadata intelligently the harvester won't delete everything that's still valid, just not updated. E.g. an api that allows retrieval of only updated datasets rather than reimporting all datasets can't simply delete everything else