### PR TITLE
DL-300 laep harvester

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/laep.py
+++ b/ckanext/datapress_harvester/harvesters2/laep.py
@@ -1,3 +1,4 @@
+
 import dateutil.parser
 
 import requests
@@ -24,12 +25,35 @@ class LAEPCollect(Collector[dict[str, Any], dict[str, Any]]):
 
     @classmethod
     def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+
+        # todo simpler dcat parsing method
+
+
+        # not sure how structured title, description, format are
+        resources = []
+        for distribution in source_data["dcat:distribution"]:
+
+            resource = {
+                "name": distribution.get("dct:title") or distribution.get("dct:description"),
+                "format": distribution.get("dct:format", {}).get("@id","")
+            }
+
+            # if no distribution then assume link to main page
+            if "dcat:accessURL" in distribution:
+                resource["url"] = distribution["dcat:accessURL"]["@id"]
+            else:
+                resource["url"] = source_data["dct:landingPage"]
+
+            resources.append(resource)
+
         yield SimpleStandard(
             package_id=SimpleStandard.create_hashed_id(cls.gather_identifier(source_data)),
             org_name=org_name,
             upstream_url=cls.dcat_url,
             title=source_data["dct:title"],
             description=source_data["dct:description"],
+
+            resources=resources,
 
             # datetime.isoformat() works with a trailing z from python3.11 onwards
             upstream_metadata_modified=dateutil.parser.isoparse(source_data["dct:modified"]["@value"]),

--- a/ckanext/datapress_harvester/harvesters2/laep.py
+++ b/ckanext/datapress_harvester/harvesters2/laep.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import dateutil.parser
 
 import requests
 from typing import Any, Iterable
@@ -7,35 +7,32 @@ from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleS
 
 
 class LAEPCollect(Collector[dict[str, Any], dict[str, Any]]):
-
-    dcat_url = "https://laep-datahub-alpha-cityhall.hub.arcgis.com/api/feed/dcat-ap/2.0.1.json"
+    dcat_url = "https://laep-datahub-alpha-cityhall.hub.arcgis.com/api/feed/dcat-ap/3.0.0.json"
 
     @classmethod
     def gather(cls) -> list[dict[str, Any]]:
-
         content = requests.get(cls.dcat_url).json()
         return content["dcat:dataset"]
 
     @classmethod
     def gather_identifier(cls, source_data: dict[str, Any]) -> str:
-
         return source_data["@id"]
 
     @classmethod
-    def fetch(cls, from_url: dict[str, Any]) -> dict[str, Any]:
-
-        return from_url
+    def fetch(cls, source_data: dict[str, Any]) -> dict[str, Any]:
+        return source_data
 
     @classmethod
     def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
-
         yield SimpleStandard(
             package_id=SimpleStandard.create_hashed_id(cls.gather_identifier(source_data)),
             org_name=org_name,
             upstream_url=cls.dcat_url,
             title=source_data["dct:title"],
             description=source_data["dct:description"],
-            upstream_metadata_modified=datetime.fromisoformat(source_data["dct:modified"]),
-            upstream_metadata_created=datetime.fromisoformat(source_data["dct:issued"]),
-            author=source_data["dct:publisher"]
+
+            # datetime.isoformat() works with a trailing z from python3.11 onwards
+            upstream_metadata_modified=dateutil.parser.isoparse(source_data["dct:modified"]["@value"]),
+            upstream_metadata_created=dateutil.parser.isoparse(source_data["dct:issued"]["@value"]),
+            author=source_data["dct:publisher"]["foaf:name"]
         )

--- a/ckanext/datapress_harvester/harvesters2/laep.py
+++ b/ckanext/datapress_harvester/harvesters2/laep.py
@@ -33,8 +33,10 @@ class LAEPCollect(Collector[dict[str, Any], dict[str, Any]]):
         resources = []
         for distribution in source_data["dcat:distribution"]:
 
+            # move description to title if there isn't a title
             resource = {
-                "name": distribution.get("dct:title") or distribution.get("dct:description"),
+                "name": distribution.get("dct:title") or distribution.get("dct:description") or source_data["dct:title"],
+                "description": distribution.get("dct:description") if "dct:title" in distribution else "",
                 "format": distribution.get("dct:format", {}).get("@id","")
             }
 

--- a/ckanext/datapress_harvester/harvesters2/laep.py
+++ b/ckanext/datapress_harvester/harvesters2/laep.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+import requests
+from typing import Any, Iterable
+
+from ckanext.datapress_harvester.harvesters2.lib.utils import Collector, SimpleStandard
+
+
+class LAEPCollect(Collector[dict[str, Any], dict[str, Any]]):
+
+    dcat_url = "https://laep-datahub-alpha-cityhall.hub.arcgis.com/api/feed/dcat-ap/2.0.1.json"
+
+    @classmethod
+    def gather(cls) -> list[dict[str, Any]]:
+
+        content = requests.get(cls.dcat_url).json()
+        return content["dcat:dataset"]
+
+    @classmethod
+    def gather_identifier(cls, source_data: dict[str, Any]) -> str:
+
+        return source_data["@id"]
+
+    @classmethod
+    def fetch(cls, from_url: dict[str, Any]) -> dict[str, Any]:
+
+        return from_url
+
+    @classmethod
+    def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+
+        yield SimpleStandard(
+            package_id=SimpleStandard.create_hashed_id(cls.gather_identifier(source_data)),
+            org_name=org_name,
+            upstream_url=cls.dcat_url,
+            title=source_data["dct:title"],
+            description=source_data["dct:description"],
+            upstream_metadata_modified=datetime.fromisoformat(source_data["dct:modified"]),
+            upstream_metadata_created=datetime.fromisoformat(source_data["dct:issued"]),
+            author=source_data["dct:publisher"]
+        )

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Any, Dict
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
-from ckanext.datapress_harvester.harvesters2 import fingertips, tflunified, ukpn, tflopen
+from ckanext.datapress_harvester.harvesters2 import fingertips, tflunified, ukpn, tflopen, laep
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
@@ -193,4 +193,18 @@ class TflOpenHarvester(SimpleHarvester):
             "name": "tfl-open-data",
             "title": "TfL Open Data",
             "description": "Harvests from TfL's Open Data Summary page"
+        }
+
+class LAEPHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector() -> laep.LAEPCollect:
+        return laep.LAEPCollect()
+
+    @staticmethod
+    def info() -> dict[str, str]:
+        return {
+            "name": "laep",
+            "title": "LAEP",
+            "description": "Harvests from the Local Area Energy Planning datahub"
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests
 beautifulsoup4
 xmltodict
-date
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests
 beautifulsoup4
 xmltodict
+date
+python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         ukpn_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:UkpnHarvester
         fingertips_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:FingertipsHarvester
         tflopen_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:TflOpenHarvester
+        laep_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:LAEPHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel


### PR DESCRIPTION
First version of harvesting from the LAEP datahub

Add python-dateutils to requirements as a convenient way of handling dates for future harvesters

Uses the DCAT 3.0 api which combines the arcgis purpose & description into one description that isn't always very readable

See https://www.arcgis.com/home/item.html?id=412c2f675e5f4401bb33c8a4f0910c39 - the longer description with a table is appended to the shorter description, but without any formatting so it comes out as one long piece of text with no markup

"Estimates of the numbers (and capacity) of off-street electric vehicle (EV) chargepoints, per LSOA. Author: Buro Happold Creation date: November 2024 Date of source data harvest: January 2024 (LOTI) & March 2024 (DfT) Temporal coverage of source data: 2023 Spatial Resolution: Lower Super Output Area (LSOA) Geometry: Polygon Source data URL: DfT Electric Vehicle Statistics...."


