### PR TITLE
Dl 132 esri instant atlas

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -1,9 +1,7 @@
-
 import requests
 from typing import Any, Iterable
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
-
 
 class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
     # Two API endpoints are used here: arc_gis_url to get a list of indicators,
@@ -84,6 +82,10 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
 
     @classmethod
     def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+        # Handle required description field being 'null' for some indicators
+        if source_data.get("Description") is None:
+            raise ValueError(
+                "Description needs to be provided for the data source.")
 
         yield SimpleStandard(
             package_id=SimpleStandard.create_hashed_id(
@@ -99,6 +101,5 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
             private=False,
             geography_level=source_data.get("Spatial"),
             update_frequency=source_data.get("Frequency"),
-            notes=source_data.get("Methodology"),
             data_updated_at=source_data.get("LastUpdated"),
         )

--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -1,0 +1,104 @@
+
+import requests
+from typing import Any, Iterable
+
+from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
+
+
+class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
+    # Two API endpoints are used here: arc_gis_url to get a list of indicators,
+    # and instant_atlas_url to get detailed metadata for each indicator.
+    arc_gis_url = "https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Richmond_upon_Thames_MasterTable/FeatureServer/0/query"
+    instant_atlas_url = "https://hub.instantatlas.com/data-catalog-metadata-service/query"
+
+    @classmethod
+    def gather(cls) -> list[dict[str, Any]]:
+        # Gather all indicators
+        page_size = 2000
+        current_offset = 0
+        all_features: list[dict[str, Any]] = []
+
+        while True:
+            ag_params = {
+                # request the specific fields we need
+                'f': 'json',
+                'where': "Item_Type='Indicator'",
+                'outFields': 'ID,Item_Type,Name,Short_Name,Theme_ID',
+                'resultOffset': current_offset,
+                'resultRecordCount': page_size,
+                'returnDistinctValues': 'true'
+            }
+
+            arc_gis_resp = requests.get(cls.arc_gis_url, params=ag_params)
+            arc_gis_resp.raise_for_status()
+            # Consider renaming variable for clarity or moving json() call directly into features extraction
+            feature_data = arc_gis_resp.json()
+
+            features = feature_data.get('features') or []
+            if not features:
+                break
+
+            all_features.extend(features)
+
+            # if no more features, break the loop
+            if len(features) < page_size:
+                break
+
+            current_offset += len(features)
+
+        feature_ids = [feature['attributes']['ID'] for feature in all_features]
+
+        # Gather detailed metadata for each indicator in batches
+        batch_size = 100
+        all_metadata_features = []
+        for i in range(0, len(feature_ids), batch_size):
+            batch_ids = feature_ids[i:i+batch_size]
+            # Use where parameter to batch request indicators and filter indicators with non-null title as this is the master version containing the metadata.
+            where_clause = f"IndicatorID IN ({','.join([repr(j) for j in batch_ids])}) AND Title IS NOT NULL"
+            ia_params = {
+                'f': 'json',
+                'outFields': '*',
+                'where': where_clause,
+                'resultOffset': 0
+            }
+            instant_atlas_resp = requests.get(
+                cls.instant_atlas_url, params=ia_params)
+            instant_atlas_resp.raise_for_status()
+            instant_atlas_data = instant_atlas_resp.json()
+            batch_features = instant_atlas_data.get('features', [])
+            all_metadata_features.extend(batch_features)
+
+        # Flatten features: remove 'attributes' key
+        flattened_metadata = [f['attributes']
+                              for f in all_metadata_features if 'attributes' in f]
+
+        return flattened_metadata
+
+    @classmethod
+    def gather_identifier(cls, source_data: dict[str, Any]) -> str:
+        return source_data["IndicatorID"]
+
+    @classmethod
+    def fetch(cls, source_data: dict[str, Any]) -> dict[str, Any]:
+        return source_data
+
+    @classmethod
+    def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+
+        yield SimpleStandard(
+            package_id=SimpleStandard.create_hashed_id(
+                cls.gather_identifier(source_data)),
+            org_name=org_name,
+            # using instant atlas metadata service as upstream url
+            upstream_url=cls.instant_atlas_url,
+            title=source_data.get("Title", ""),
+            description=source_data.get("Description", ""),
+            url=source_data.get("Source_URL", ""),
+            author=source_data.get("Publisher", ""),
+            license_title=source_data.get("Rights", ""),
+            private=False,
+            geography_level=source_data.get("Spatial"),
+            update_frequency=source_data.get("Frequency"),
+            notes=source_data.get("Methodology"),
+            data_updated_at=source_data.get("LastUpdated"),
+        )

--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -4,13 +4,16 @@ from typing import Any, Iterable
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
 
 class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
-    # Two API endpoints are used here: arc_gis_url to get a list of indicators,
+    # Two API endpoints are used here: arc_gis_url (from harvester config json parameter 'url') to get a list of indicators,
     # and instant_atlas_url to get detailed metadata for each indicator.
-    arc_gis_url = "https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Richmond_upon_Thames_MasterTable/FeatureServer/0/query"
-    instant_atlas_url = "https://hub.instantatlas.com/data-catalog-metadata-service/query"
 
-    @classmethod
-    def gather(cls) -> list[dict[str, Any]]:
+    def __init__(self, arc_gis_url: str) -> None:
+        # Pass the URL up to the base Collector class as harvest_url
+        super().__init__(harvest_url=arc_gis_url)
+        self.arc_gis_url = arc_gis_url
+        self.instant_atlas_url = "https://hub.instantatlas.com/data-catalog-metadata-service/query"
+
+    def gather(self) -> list[dict[str, Any]]:
         # Gather all indicators
         page_size = 2000
         current_offset = 0
@@ -27,7 +30,7 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
                 'returnDistinctValues': 'true'
             }
 
-            arc_gis_resp = requests.get(cls.arc_gis_url, params=ag_params)
+            arc_gis_resp = requests.get(self.arc_gis_url, params=ag_params)
             arc_gis_resp.raise_for_status()
             # Consider renaming variable for clarity or moving json() call directly into features extraction
             feature_data = arc_gis_resp.json()
@@ -60,7 +63,7 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
                 'resultOffset': 0
             }
             instant_atlas_resp = requests.get(
-                cls.instant_atlas_url, params=ia_params)
+                self.instant_atlas_url, params=ia_params)
             instant_atlas_resp.raise_for_status()
             instant_atlas_data = instant_atlas_resp.json()
             batch_features = instant_atlas_data.get('features', [])
@@ -72,16 +75,13 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
 
         return flattened_metadata
 
-    @classmethod
-    def gather_identifier(cls, source_data: dict[str, Any]) -> str:
+    def gather_identifier(self, source_data: dict[str, Any]) -> str:
         return source_data["IndicatorID"]
 
-    @classmethod
-    def fetch(cls, source_data: dict[str, Any]) -> dict[str, Any]:
+    def fetch(self, source_data: dict[str, Any]) -> dict[str, Any]:
         return source_data
 
-    @classmethod
-    def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+    def transform(self, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
         # Handle required description field being 'null' for some indicators
         if source_data.get("Description") is None:
             raise ValueError(
@@ -89,10 +89,10 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
 
         yield SimpleStandard(
             package_id=SimpleStandard.create_hashed_id(
-                cls.gather_identifier(source_data)),
+                self.gather_identifier(source_data)),
             org_name=org_name,
             # using instant atlas metadata service as upstream url
-            upstream_url=cls.instant_atlas_url,
+            upstream_url=self.instant_atlas_url,
             title=source_data.get("Title", ""),
             description=source_data.get("Description", ""),
             url=source_data.get("Source_URL", ""),

--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -32,8 +32,9 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
         page_size = 2000
         current_offset = 0
         all_features: list[dict[str, Any]] = []
+        max_iterations = 1000  # safeguard to prevent infinite loops from API changes
 
-        while True:
+        for _ in range(max_iterations):
             ag_params = {
                 # request the specific fields we need
                 'f': 'json',
@@ -60,6 +61,10 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
                 break
 
             current_offset += len(features)
+
+        else:
+            raise RuntimeError(
+                "Max iterations reached while gathering indicators. The external API may have changed behavior.")
 
         feature_ids = [feature['attributes']['ID'] for feature in all_features]
 

--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -9,8 +9,8 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
     # and instant_atlas_url to get detailed metadata for each indicator.
 
     def __init__(self, arc_gis_url: str) -> None:
-        # Pass the URL up to the base Collector class as harvest_url
-        super().__init__(harvest_url=arc_gis_url)
+        # Pass the URL up to the base Collector class as target_url
+        super().__init__(target_url=arc_gis_url)
         self.arc_gis_url = arc_gis_url
         self.instant_atlas_url = "https://hub.instantatlas.com/data-catalog-metadata-service/query"
 

--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -1,3 +1,4 @@
+import re
 import requests
 from typing import Any, Iterable
 
@@ -12,6 +13,19 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
         super().__init__(harvest_url=arc_gis_url)
         self.arc_gis_url = arc_gis_url
         self.instant_atlas_url = "https://hub.instantatlas.com/data-catalog-metadata-service/query"
+
+    def _extract_org_identifier(self, url: str) -> str:
+        """Extract organization identifier from ArcGIS URL.
+        
+        Example: https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Hounslow_MasterTable/FeatureServer/0/query
+        Returns: Hounslow_MasterTable
+        """
+        # Match the service name before /FeatureServer
+        match = re.search(r'/services/([^/]+)/FeatureServer', url)
+        if match:
+            return match.group(1)
+        # Fallback: use the entire URL hash if pattern doesn't match
+        return SimpleStandard.create_hashed_id(url)[:8]
 
     def gather(self) -> list[dict[str, Any]]:
         # Gather all indicators
@@ -76,7 +90,10 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
         return flattened_metadata
 
     def gather_identifier(self, source_data: dict[str, Any]) -> str:
-        return source_data["IndicatorID"]
+        # Create unique identifier combining org and indicator to avoid id duplication across different orgs
+        indicator_id = source_data["IndicatorID"]
+        org_identifier = self._extract_org_identifier(self.arc_gis_url)
+        return f"{org_identifier}_{indicator_id}"
 
     def fetch(self, source_data: dict[str, Any]) -> dict[str, Any]:
         return source_data

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -37,7 +37,21 @@ class FingertipsHarvester(SimpleHarvester):
         }
 """
 
+
 class SimpleHarvester(HarvesterBase):
+
+    def _set_config(self, config_str) -> None:
+        # Handle empty config string
+        if not config_str or not config_str.strip():
+            self.config = {}
+        else:
+            self.config = json.loads(config_str)
+
+            if 'url' in self.config:
+                # Set url from config if it is provided
+                logging.debug(
+                    f"Using URL parameter from harvester config: {self.config['url']}")
+                self.url = self.config['url']
 
     @staticmethod
     @abstractmethod
@@ -52,6 +66,8 @@ class SimpleHarvester(HarvesterBase):
     def gather_stage(self, harvest_job):
         try:
             logging.info(f"Gathering {self.info()['name']}")
+
+            self._set_config(harvest_job.source.config)
 
             gathered_items = self.collector().gather()
             all_jobs = []
@@ -74,13 +90,16 @@ class SimpleHarvester(HarvesterBase):
         except Exception as e:
             # todo set up proper exceptions
             logging.error(f"Gather failed: {str(e)}")
-            self._save_gather_error(f"Couldn't gather {self.info()['name']}", harvest_job)
+            self._save_gather_error(
+                f"Couldn't gather {self.info()['name']}", harvest_job)
 
         return []
 
     def fetch_stage(self, harvest_object):
 
         logging.info(f"Fetching {self.info()['name']}")
+
+        self._set_config(harvest_object.source.config)
 
         try:
 
@@ -91,7 +110,8 @@ class SimpleHarvester(HarvesterBase):
             # todo set up proper exceptions
             # may be useful https://github.com/GSA/data.gov/wiki/Examples-of-Harvest-Job-Errors
             logging.error(f"Failed to fetch {harvest_object.guid}: {str(e)}")
-            self._save_object_error(f"Couldn't fetch id {harvest_object.guid}, see logs for detail", harvest_object)
+            self._save_object_error(
+                f"Couldn't fetch id {harvest_object.guid}, see logs for detail", harvest_object)
 
             return False
 
@@ -131,7 +151,8 @@ class SimpleHarvester(HarvesterBase):
             # todo set up proper exceptions
             # may be useful https://github.com/GSA/data.gov/wiki/Examples-of-Harvest-Job-Errors
             logging.error(f"Failed to import {harvest_object.guid}: {str(e)}")
-            self._save_object_error(f"Couldn't import id {harvest_object.guid}, see logs for detail", harvest_object)
+            self._save_object_error(
+                f"Couldn't import id {harvest_object.guid}, see logs for detail", harvest_object)
 
         return False
 
@@ -195,6 +216,7 @@ class TflOpenHarvester(SimpleHarvester):
             "description": "Harvests from TfL's Open Data Summary page"
         }
 
+
 class LAEPHarvester(SimpleHarvester):
 
     @staticmethod
@@ -212,9 +234,17 @@ class LAEPHarvester(SimpleHarvester):
 
 class InstantAtlasHarvester(SimpleHarvester):
 
-    @staticmethod
-    def collector() -> instantatlas.InstantAtlasCollect:
-        return instantatlas.InstantAtlasCollect()
+    def _set_config(self, config_str) -> None:
+        super()._set_config(config_str)
+        # InstantAtlas requires URL in config
+        if not self.config.get('url'):
+            raise ValueError(
+                "InstantAtlasHarvester requires 'url' in configuration. "
+                "Please ensure config contains a valid 'url' parameter.")
+
+    def collector(self) -> instantatlas.InstantAtlasCollect:
+        # return a collector instance passing the provided url from config
+        return instantatlas.InstantAtlasCollect(self.url)
 
     @staticmethod
     def info() -> dict[str, str]:

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Any, Dict
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
-from ckanext.datapress_harvester.harvesters2 import fingertips, tflunified, ukpn, tflopen, laep
+from ckanext.datapress_harvester.harvesters2 import fingertips, tflunified, ukpn, tflopen, laep, instantatlas
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
@@ -207,4 +207,19 @@ class LAEPHarvester(SimpleHarvester):
             "name": "laep",
             "title": "LAEP",
             "description": "Harvests from the Local Area Energy Planning datahub"
+        }
+
+
+class InstantAtlasHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector() -> instantatlas.InstantAtlasCollect:
+        return instantatlas.InstantAtlasCollect()
+
+    @staticmethod
+    def info() -> dict[str, str]:
+        return {
+            "name": "instant-atlas",
+            "title": "Instant Atlas",
+            "description": "Harvests from the ESRI InstantAtlas portals"
         }

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -244,7 +244,7 @@ class InstantAtlasHarvester(SimpleHarvester):
 
     def collector(self) -> instantatlas.InstantAtlasCollect:
         # return a collector instance passing the provided url from config
-        return instantatlas.InstantAtlasCollect(self.url)
+        return instantatlas.InstantAtlasCollect(arc_gis_url=self.url)
 
     @staticmethod
     def info() -> dict[str, str]:

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -115,7 +115,7 @@ class Collector(ABC, Generic[A,B]):
     """
 
     def __init__(self, target_url: Optional[str] = None) -> None:
-        self.target_url = target_url
+        self._target_url = target_url
 
     @classmethod
     @abstractmethod

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -114,8 +114,8 @@ class Collector(ABC, Generic[A,B]):
     It's important to remember steps may be run independently in pipelines in future - hence classmethod
     """
 
-    def __init__(self, harvest_url: Optional[str] = None) -> None:
-        self.harvest_url = harvest_url
+    def __init__(self, target_url: Optional[str] = None) -> None:
+        self.target_url = target_url
 
     @classmethod
     @abstractmethod

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -114,6 +114,9 @@ class Collector(ABC, Generic[A,B]):
     It's important to remember steps may be run independently in pipelines in future - hence classmethod
     """
 
+    def __init__(self, harvest_url: Optional[str] = None) -> None:
+        self.harvest_url = harvest_url
+
     @classmethod
     @abstractmethod
     def gather(cls) -> Iterable[A]:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         fingertips_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:FingertipsHarvester
         tflopen_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:TflOpenHarvester
         laep_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:LAEPHarvester
+        instantatlas_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:InstantAtlasHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel


### PR DESCRIPTION
relates to: https://london.atlassian.net/browse/DL-132

Initial ESRI Instant Atlas portal harvester implementation.

It harvests from InstantAtlas Data Explorer local authority portals (harvested sources correspond to what is available e.g. here: https://www.datarich.info/data-catalog-explorer/)

Target harvest url is defined in harvester config using a 'url' parameter. Example url has the following format: 
'https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Richmond_upon_Thames_MasterTable/FeatureServer/0/query'

Specific urls can be sourced by searching network tab in developer tools on the relevant portal.

Most local authority portals share the same instant atlas datasets. Hence, this iteration handles duplicate datasets by adding an org specific suffix to package id.

As some datasets don't provide description it is handled by raising an error and these sources will remain unharvested. 