### PR TITLE
DL-355 esri instantatlas general pages

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -1,10 +1,13 @@
 import re
 import requests
+import logging
 from typing import Any, Iterable
 
 from bs4 import BeautifulSoup
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
+
+logging = logging.getLogger(__name__)
 
 class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
     """Collector for Instant Atlas based data portals.
@@ -21,22 +24,23 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
     {
         "url_source": "https://www.croydonobservatory.org/",
         "url_arc_gis": "https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Croydon_MasterTable/FeatureServer/0/query",
-        "themes_tab": "Croydon Profile"
+        "target_tabs": ["Croydon Profile", "Census 2021", "Equalities", "Health and Wellbeing"]
     }
     """
 
-    def __init__(self, source_page_url: str, arc_gis_url: str, themes_tab: str) -> None:
+    def __init__(self, source_page_url: str, arc_gis_url: str, target_tabs: Iterable[str]) -> None:
         # Pass the configuration up to the base Collector class
         super().__init__(target_source_url=source_page_url,
-                         target_arc_gis_url=arc_gis_url, themes_tab=themes_tab)
+                         target_arc_gis_url=arc_gis_url, target_tabs=target_tabs)
 
         self.source_page_url = source_page_url
         self.arc_gis_url = arc_gis_url
-        self.themes_tab = themes_tab
+        self.target_tabs = target_tabs
         # Instant Atlas metadata service URL, same for all portals
         self.instant_atlas_url = "https://hub.instantatlas.com/data-catalog-metadata-service/query"
 
     def _extract_org_identifier(self, url: str) -> str:
+
         """Extract organization identifier from ArcGIS URL.
         
         Example: https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Hounslow_MasterTable/FeatureServer/0/query
@@ -108,6 +112,7 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
                 'where': where_clause,
                 'resultOffset': 0
             }
+
             instant_atlas_resp = requests.get(
                 self.instant_atlas_url, params=ia_params)
             instant_atlas_resp.raise_for_status()
@@ -120,96 +125,122 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
                               for f in all_metadata_features if 'attributes' in f]
         return flattened_metadata
 
-    def _gather_from_themes_pages(self) -> list[dict[str, Any]]:
-        """Gathers metadata by scraping themes pages from the source portal website.
-        
-        **Note:** This assumes a specific HTML structure for the portal pages. 
-        Currently does not work for portals that rely on JavaScript injected report content to extract metadata from. 
-        """
-
-        # Add headers to mimic a real browser request (otherwise it is blocked by the server)
+    def _get_soup(self, url: str) -> BeautifulSoup:
+        '''Fetches the HTML content of a URL and returns a BeautifulSoup object.'''
         headers = {
             "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/117.0"
         }
-        content = requests.get(self.source_page_url, headers=headers).text
-        soup = BeautifulSoup(content, "html.parser")
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return BeautifulSoup(response.text, "html.parser")
 
-        # Extract theme page URLs
-        theme_urls = []
+    def _extract_urls_from_nav_tabs(self, soup: BeautifulSoup, tab_names: Iterable[str]) -> list[str]:
+        """Extracts URLs from navigation tabs on the portal page.
+        Args:
+            soup (BeautifulSoup): Parsed HTML of the portal page.
+            tab_names (Iterable[str]): Names of the top-level navigation tabs to search for.
+        Returns:
+            list[str]: List of extracted URLs from the specified tabs.
+        """
 
-        themes_tab_link = soup.find("a", string=self.themes_tab)
+        page_urls: list[str] = []
 
-        if not themes_tab_link:
-            raise ValueError(
-                f"No matching themes tab with the name:'{self.themes_tab}' found on source page. Possible harvester configuration error.")
+        for tab_name in tab_names:
+            link = soup.find("a", string=tab_name)
 
-        parent_li = themes_tab_link.find_parent(
-            "li") if themes_tab_link else None
-        theme_list_elements = parent_li.find_all("li") if parent_li else []
+            if not link:
+                logging.error(
+                    f"Navigation tab '{tab_name}' not found in the page. Skipping...")
+                continue
 
-        for list_element in theme_list_elements:
-            link_element = list_element.find("a")
-            href = link_element.get("href") if link_element else None
+            parent_li = link.find_parent("li")
+            if not parent_li:
+                continue
 
-            if href and href != '#':
-                theme_urls.append(href)
+            # Case 1: tab has a submenu → collect all child links
+            submenu = parent_li.find("ul", class_="sub-menu")
+            if submenu:
+                for li in submenu.find_all("li"):
+                    a = li.find("a")
+                    href = a.get("href") if a else None
+                    if href and href != "#":
+                        page_urls.append(href)
 
-        # For each theme page, extract metadata
-        all_theme_metadata = []
-        for theme_url in theme_urls:
-            theme_content = requests.get(theme_url, headers=headers).text
-            theme_soup = BeautifulSoup(theme_content, "html.parser")
+            # Case 2: tab is a direct link
+            else:
+                href = link.get("href")
+                if href and href != "#":
+                    page_urls.append(href)
 
-            # Extract description
-            theme_desc_elements = []
+        # Remove potential duplicates
+        unique_urls = set(page_urls)
+        return list(unique_urls)
 
-            for content_div in theme_soup.find_all("div", class_="entry-content"):
-                parapraphs = content_div.find_all("p")
+    def _extract_page_metadata(self, soup: BeautifulSoup, url: str) -> dict[str, Any]:
+        '''Extracts metadata (title and description) from a given page's HTML soup.
+        Args:
+            soup (BeautifulSoup): Parsed HTML of the page.
+            url (str): URL of the page (used for source/upstream URL fields).
+        Returns:
+            dict[str, Any]: Extracted metadata
+        '''
 
-                if not parapraphs:
-                    # Set to None if no description paragraphs found so it is consistent with API returned metadata and can be handled appropriately at transform stage
-                    # Should there be a default value instead in order to still harvest the resource?
-                    theme_desc_elements = None
-                    continue
+        desc_elements: list[str] | None = []
 
-                for p in parapraphs:
-                    text = p.get_text(strip=True)
-                    # Skip empty paragraphs
-                    if not text:
-                        continue
+        for content_div in soup.find_all("div", class_="entry-content"):
+            paragraphs = content_div.find_all("p")
 
-                    # TODO: Description extraction is imperfect, may need further refinement to avoid unrelated text in some cases.
-                    if theme_desc_elements is not None:
-                        theme_desc_elements.append(text)
+            if not paragraphs:
+                desc_elements = None
+                continue
 
-            theme_desc = "\n\n".join(
-                theme_desc_elements) if theme_desc_elements else None
+            for p in paragraphs:
+                text = p.get_text(strip=True)
+                if text and desc_elements is not None:
+                    desc_elements.append(text)
 
-            # Extract title
-            title_element = theme_soup.select_one(
-                "header.page-header .page-title")
-            theme_title = title_element.get_text(
-                strip=True) if title_element else None
+        description = "\n\n".join(desc_elements) if desc_elements else None
 
-            theme_metadata: dict[str, Any] = {
-                "Title": theme_title,
-                "Description": theme_desc,
-                "Source_URL": theme_url,
-                "Upstream_URL": theme_url}
+        title_el = soup.select_one("header.page-header .page-title")
+        title = title_el.get_text(strip=True) if title_el else None
 
-            all_theme_metadata.append(theme_metadata)
+        return {
+            "Title": title,
+            "Description": description,
+            "Source_URL": url,
+            "Upstream_URL": url,
+        }
 
-        return all_theme_metadata
+    def _gather_from_general_pages(self, tab_names: Iterable[str]) -> list[dict[str, Any]]:
+        """Gathers metadata from general pages under specified navigation tabs.
+        Args:
+            tab_names (Iterable[str]): Names of the top-level navigation tabs to gather from.
+        Returns:
+            list[dict[str, Any]]: List of gathered metadata dictionaries.
+        """
+
+        all_page_metadata = []
+
+        soup = self._get_soup(self.source_page_url)
+        urls = self._extract_urls_from_nav_tabs(soup, tab_names)
+
+        for url in urls:
+            page_soup = self._get_soup(url)
+            page_metadata = self._extract_page_metadata(page_soup, url)
+
+            all_page_metadata.append(page_metadata)
+
+        return all_page_metadata
 
     def gather(self) -> list[dict[str, Any]]:
-        # SOURCE 1: Gather metadata from themes pages via scraping
-        themes_metadata = self._gather_from_themes_pages()
+        # SOURCE 1: Gather metadata from general pages via scraping
+        pages_metadata = self._gather_from_general_pages(self.target_tabs)
 
         # SOURCE 2: Gather metadata from Data Explorer via ArcGIS API
         data_explorer_metadata = self._gather_from_data_explorer()
 
         # Combine all metadata sources
-        all_gathered_metadata = themes_metadata + data_explorer_metadata
+        all_gathered_metadata = pages_metadata + data_explorer_metadata
 
         return all_gathered_metadata
 

--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -2,16 +2,38 @@ import re
 import requests
 from typing import Any, Iterable
 
+from bs4 import BeautifulSoup
+
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
 
 class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
-    # Two API endpoints are used here: arc_gis_url (from harvester config json parameter 'url') to get a list of indicators,
-    # and instant_atlas_url to get detailed metadata for each indicator.
+    """Collector for Instant Atlas based data portals.
+    Gathers metadata from two sources:
+    1. themes pages on the portal website (scraped HTML)
+    2. Data Explorer via ArcGIS API
+    Configurable with three required parameters:
+    - source_page_url: URL of the main portal page containing themes links
+    - arc_gis_url: URL of the ArcGIS FeatureServer query endpoint for data explorer
+    - themes_tab: Name of the top-level tab on the portal page that contains theme links
+    
+    Example json config string:
+    .. code-block:: json
+    {
+        "url_source": "https://www.croydonobservatory.org/",
+        "url_arc_gis": "https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Croydon_MasterTable/FeatureServer/0/query",
+        "themes_tab": "Croydon Profile"
+    }
+    """
 
-    def __init__(self, arc_gis_url: str) -> None:
-        # Pass the URL up to the base Collector class as target_url
-        super().__init__(target_url=arc_gis_url)
+    def __init__(self, source_page_url: str, arc_gis_url: str, themes_tab: str) -> None:
+        # Pass the configuration up to the base Collector class
+        super().__init__(target_source_url=source_page_url,
+                         target_arc_gis_url=arc_gis_url, themes_tab=themes_tab)
+
+        self.source_page_url = source_page_url
         self.arc_gis_url = arc_gis_url
+        self.themes_tab = themes_tab
+        # Instant Atlas metadata service URL, same for all portals
         self.instant_atlas_url = "https://hub.instantatlas.com/data-catalog-metadata-service/query"
 
     def _extract_org_identifier(self, url: str) -> str:
@@ -20,6 +42,7 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
         Example: https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Hounslow_MasterTable/FeatureServer/0/query
         Returns: Hounslow_MasterTable
         """
+
         # Match the service name before /FeatureServer
         match = re.search(r'/services/([^/]+)/FeatureServer', url)
         if match:
@@ -27,8 +50,12 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
         # Fallback: use the entire URL hash if pattern doesn't match
         return SimpleStandard.create_hashed_id(url)[:8]
 
-    def gather(self) -> list[dict[str, Any]]:
-        # Gather all indicators
+    def _gather_from_data_explorer(self) -> list[dict[str, Any]]:
+        """Gathers metadata from Data Explorer via ArcGIS API.
+
+        Two API endpoints are used here: arc_gis_url (from harvester config json parameter 'url') to get a list of indicators,
+        and instant_atlas_url to get detailed metadata for each indicator."""
+
         page_size = 2000
         current_offset = 0
         all_features: list[dict[str, Any]] = []
@@ -91,30 +118,124 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
         # Flatten features: remove 'attributes' key
         flattened_metadata = [f['attributes']
                               for f in all_metadata_features if 'attributes' in f]
-
         return flattened_metadata
+
+    def _gather_from_themes_pages(self) -> list[dict[str, Any]]:
+        """Gathers metadata by scraping themes pages from the source portal website.
+        
+        **Note:** This assumes a specific HTML structure for the portal pages. 
+        Currently does not work for portals that rely on JavaScript injected report content to extract metadata from. 
+        """
+
+        # Add headers to mimic a real browser request (otherwise it is blocked by the server)
+        headers = {
+            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/117.0"
+        }
+        content = requests.get(self.source_page_url, headers=headers).text
+        soup = BeautifulSoup(content, "html.parser")
+
+        # Extract theme page URLs
+        theme_urls = []
+
+        themes_tab_link = soup.find("a", string=self.themes_tab)
+
+        if not themes_tab_link:
+            raise ValueError(
+                f"No matching themes tab with the name:'{self.themes_tab}' found on source page. Possible harvester configuration error.")
+
+        parent_li = themes_tab_link.find_parent(
+            "li") if themes_tab_link else None
+        theme_list_elements = parent_li.find_all("li") if parent_li else []
+
+        for list_element in theme_list_elements:
+            link_element = list_element.find("a")
+            href = link_element.get("href") if link_element else None
+
+            if href and href != '#':
+                theme_urls.append(href)
+
+        # For each theme page, extract metadata
+        all_theme_metadata = []
+        for theme_url in theme_urls:
+            theme_content = requests.get(theme_url, headers=headers).text
+            theme_soup = BeautifulSoup(theme_content, "html.parser")
+
+            # Extract description
+            theme_desc_elements = []
+
+            for content_div in theme_soup.find_all("div", class_="entry-content"):
+                parapraphs = content_div.find_all("p")
+
+                if not parapraphs:
+                    # Set to None if no description paragraphs found so it is consistent with API returned metadata and can be handled appropriately at transform stage
+                    # Should there be a default value instead in order to still harvest the resource?
+                    theme_desc_elements = None
+                    continue
+
+                for p in parapraphs:
+                    text = p.get_text(strip=True)
+                    # Skip empty paragraphs
+                    if not text:
+                        continue
+
+                    # TODO: Description extraction is imperfect, may need further refinement to avoid unrelated text in some cases.
+                    if theme_desc_elements is not None:
+                        theme_desc_elements.append(text)
+
+            theme_desc = "\n\n".join(
+                theme_desc_elements) if theme_desc_elements else None
+
+            # Extract title
+            title_element = theme_soup.select_one(
+                "header.page-header .page-title")
+            theme_title = title_element.get_text(
+                strip=True) if title_element else None
+
+            theme_metadata: dict[str, Any] = {
+                "Title": theme_title,
+                "Description": theme_desc,
+                "Source_URL": theme_url,
+                "Upstream_URL": theme_url}
+
+            all_theme_metadata.append(theme_metadata)
+
+        return all_theme_metadata
+
+    def gather(self) -> list[dict[str, Any]]:
+        # SOURCE 1: Gather metadata from themes pages via scraping
+        themes_metadata = self._gather_from_themes_pages()
+
+        # SOURCE 2: Gather metadata from Data Explorer via ArcGIS API
+        data_explorer_metadata = self._gather_from_data_explorer()
+
+        # Combine all metadata sources
+        all_gathered_metadata = themes_metadata + data_explorer_metadata
+
+        return all_gathered_metadata
 
     def gather_identifier(self, source_data: dict[str, Any]) -> str:
         # Create unique identifier combining org and indicator to avoid id duplication across different orgs
-        indicator_id = source_data["IndicatorID"]
+        indicator_id = source_data["IndicatorID"] if "IndicatorID" in source_data else source_data["Title"]
         org_identifier = self._extract_org_identifier(self.arc_gis_url)
+
         return f"{org_identifier}_{indicator_id}"
 
     def fetch(self, source_data: dict[str, Any]) -> dict[str, Any]:
         return source_data
 
     def transform(self, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
-        # Handle required description field being 'null' for some indicators
-        if source_data.get("Description") is None:
+        # Handle required description and/or title fields being 'null' for some indicators
+        if source_data.get("Description") is None or source_data.get("Title") is None:
             raise ValueError(
-                "Description needs to be provided for the data source.")
+                "Description and Title fields need to be provided as a minimum and one or both are missing. Inspect the data source.")
 
         yield SimpleStandard(
             package_id=SimpleStandard.create_hashed_id(
                 self.gather_identifier(source_data)),
             org_name=org_name,
             # using instant atlas metadata service as upstream url
-            upstream_url=self.instant_atlas_url,
+            upstream_url=source_data.get(
+                "Upstream_URL", self.instant_atlas_url),
             title=source_data.get("Title", ""),
             description=source_data.get("Description", ""),
             url=source_data.get("Source_URL", ""),

--- a/ckanext/datapress_harvester/harvesters2/instantatlas.py
+++ b/ckanext/datapress_harvester/harvesters2/instantatlas.py
@@ -17,7 +17,7 @@ class InstantAtlasCollect(Collector[dict[str, Any], dict[str, Any]]):
     Configurable with three required parameters:
     - source_page_url: URL of the main portal page containing themes links
     - arc_gis_url: URL of the ArcGIS FeatureServer query endpoint for data explorer
-    - themes_tab: Name of the top-level tab on the portal page that contains theme links
+    - target_tabs: Name of the top-level tab on the portal page that contains theme links
     
     Example json config string:
     .. code-block:: json

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -47,11 +47,16 @@ class SimpleHarvester(HarvesterBase):
         else:
             self.config = json.loads(config_str)
 
-            if 'url' in self.config:
+            if 'url_arc_gis' in self.config and 'url_source' in self.config and 'themes_tab' in self.config:
                 # Set url from config if it is provided
-                logging.debug(
-                    f"Using URL parameter from harvester config: {self.config['url']}")
-                self.url = self.config['url']
+                logging.debug(f"Using URL parameters from harvester config:\n"
+                              f"url_source: {self.config['url_source']}\n"
+                              f"url_arc_gis: {self.config['url_arc_gis']}\n"
+                              f"themes_tab: {self.config['themes_tab']}"
+                              )
+                self.url_source = self.config['url_source']
+                self.url_arc_gis = self.config['url_arc_gis']
+                self.themes_tab = self.config['themes_tab']
 
     @staticmethod
     @abstractmethod
@@ -236,15 +241,15 @@ class InstantAtlasHarvester(SimpleHarvester):
 
     def _set_config(self, config_str) -> None:
         super()._set_config(config_str)
-        # InstantAtlas requires URL in config
-        if not self.config.get('url'):
+        # InstantAtlas harvester requires mandatory parameters in config
+        if not self.config.get('url_arc_gis') or not self.config.get('url_source') or not self.config.get('themes_tab'):
             raise ValueError(
-                "InstantAtlasHarvester requires 'url' in configuration. "
-                "Please ensure config contains a valid 'url' parameter.")
+                "InstantAtlasHarvester requires 'url_arc_gis', 'url_source', and 'themes_tab' in configuration. Please ensure config contains valid config parameters.")
 
     def collector(self) -> instantatlas.InstantAtlasCollect:
         # return a collector instance passing the provided url from config
-        return instantatlas.InstantAtlasCollect(arc_gis_url=self.url)
+        return instantatlas.InstantAtlasCollect(arc_gis_url=self.url_arc_gis, source_page_url=self.url_source,
+                                                themes_tab=self.themes_tab)
 
     @staticmethod
     def info() -> dict[str, str]:

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -47,16 +47,16 @@ class SimpleHarvester(HarvesterBase):
         else:
             self.config = json.loads(config_str)
 
-            if 'url_arc_gis' in self.config and 'url_source' in self.config and 'themes_tab' in self.config:
+            if 'url_arc_gis' in self.config and 'url_source' in self.config and 'target_tabs' in self.config:
                 # Set url from config if it is provided
                 logging.debug(f"Using URL parameters from harvester config:\n"
                               f"url_source: {self.config['url_source']}\n"
                               f"url_arc_gis: {self.config['url_arc_gis']}\n"
-                              f"themes_tab: {self.config['themes_tab']}"
+                              f"target_tabs: {self.config['target_tabs']}"
                               )
                 self.url_source = self.config['url_source']
                 self.url_arc_gis = self.config['url_arc_gis']
-                self.themes_tab = self.config['themes_tab']
+                self.target_tabs = self.config['target_tabs']
 
     @staticmethod
     @abstractmethod
@@ -242,14 +242,14 @@ class InstantAtlasHarvester(SimpleHarvester):
     def _set_config(self, config_str) -> None:
         super()._set_config(config_str)
         # InstantAtlas harvester requires mandatory parameters in config
-        if not self.config.get('url_arc_gis') or not self.config.get('url_source') or not self.config.get('themes_tab'):
+        if not self.config.get('url_arc_gis') or not self.config.get('url_source') or not self.config.get('target_tabs'):
             raise ValueError(
-                "InstantAtlasHarvester requires 'url_arc_gis', 'url_source', and 'themes_tab' in configuration. Please ensure config contains valid config parameters.")
+                "InstantAtlasHarvester requires 'url_arc_gis', 'url_source', and 'target_tabs' in configuration. Please ensure config contains valid config parameters.")
 
     def collector(self) -> instantatlas.InstantAtlasCollect:
         # return a collector instance passing the provided url from config
         return instantatlas.InstantAtlasCollect(arc_gis_url=self.url_arc_gis, source_page_url=self.url_source,
-                                                themes_tab=self.themes_tab)
+                                                target_tabs=self.target_tabs)
 
     @staticmethod
     def info() -> dict[str, str]:

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -114,10 +114,10 @@ class Collector(ABC, Generic[A,B]):
     It's important to remember steps may be run independently in pipelines in future - hence classmethod
     """
 
-    def __init__(self, target_source_url: Optional[str] = None, target_arc_gis_url: Optional[str] = None, themes_tab: Optional[str] = None) -> None:
+    def __init__(self, target_source_url: Optional[str] = None, target_arc_gis_url: Optional[str] = None, target_tabs: Optional[Iterable[str]] = None) -> None:
         self._target_source_url = target_source_url
         self._target_arc_gis_url = target_arc_gis_url
-        self._themes_tab = themes_tab
+        self._target_tabs = target_tabs
 
     @classmethod
     @abstractmethod

--- a/ckanext/datapress_harvester/harvesters2/lib/utils.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/utils.py
@@ -114,8 +114,10 @@ class Collector(ABC, Generic[A,B]):
     It's important to remember steps may be run independently in pipelines in future - hence classmethod
     """
 
-    def __init__(self, target_url: Optional[str] = None) -> None:
-        self._target_url = target_url
+    def __init__(self, target_source_url: Optional[str] = None, target_arc_gis_url: Optional[str] = None, themes_tab: Optional[str] = None) -> None:
+        self._target_source_url = target_source_url
+        self._target_arc_gis_url = target_arc_gis_url
+        self._themes_tab = themes_tab
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
Relates to: https://london.atlassian.net/browse/DL-355

Extends InstantAtlas harvester to collect metadata from data portal's general pages.
It attempts to scrape metadata from all pages under selected navigation tabs.
Data portal url and top-level navigation tabs to be targeted are configured with parameters as in the example json config string below:

```
    {
        "url_source": "https://www.croydonobservatory.org/",
        "url_arc_gis": "https://services1.arcgis.com/HumUw0sDQHwJuboT/arcgis/rest/services/Croydon_MasterTable/FeatureServer/0/query",
        "target_tabs": ["Croydon Profile", "Census 2021", "Equalities", "Health and Wellbeing"]
    }
```

It aims to gather title and description from the pages using anticipated html structure.
As some pages do not include html description paragraphs and rely on JS loaded content, these will not be onboarded in this version.