### PR TITLE
Dl-375 dafni cli harvester

### DIFF
--- a/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
+++ b/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
@@ -2,19 +2,22 @@ import os
 import subprocess
 import shutil
 import json
+import logging
+
+logging = logging.getLogger(__name__)
 
 from typing import Any, Iterable
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
-
-os.environ["DAFNI_USERNAME"] = ""
-os.environ["DAFNI_PASSWORD"] = ""
 
 
 class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
 
     @classmethod
     def gather(cls) -> list[dict[str, Any]]:
+        logging.info("Gathering DAFNI datasets...")
+        logging.info("DAFNI_USERNAME: %s", os.environ["DAFNI_USERNAME"])
+        logging.info("DAFNI_PASSWORD: %s", os.environ["DAFNI_PASSWORD"])
         search_term = "OpenClim"
 
         # Get filtered datasets via the DAFNI cli
@@ -25,6 +28,8 @@ class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
         process = subprocess.run([dafni_path, "get", "datasets", "--search", search_term,
                                  "-j"], capture_output=True, text=True, check=True, env=os.environ)
         content = json.loads(process.stdout)
+        print(
+            f"Found {len(content['metadata'])} datasets matching search term '{search_term}'")
         return content["metadata"]
 
     @classmethod
@@ -47,3 +52,10 @@ class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
             author=source_data["source"],
             data_updated_at=source_data["modified_date"]
         )
+
+
+# collector = DafniCollect()
+
+# metadata = collector.gather()
+
+# print(json.dumps(metadata, indent=2))

--- a/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
+++ b/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+import shutil
+import json
+
+from typing import Any, Iterable
+
+from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
+
+os.environ["DAFNI_USERNAME"] = ""
+os.environ["DAFNI_PASSWORD"] = ""
+
+
+class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
+
+    @classmethod
+    def gather(cls) -> list[dict[str, Any]]:
+        search_term = "OpenClim"
+
+        # Get filtered datasets via the DAFNI cli
+        dafni_path = shutil.which("dafni")
+        if not dafni_path:
+            raise RuntimeError("dafni CLI not found on PATH")
+
+        process = subprocess.run([dafni_path, "get", "datasets", "--search", search_term,
+                                 "-j"], capture_output=True, text=True, check=True, env=os.environ)
+        content = json.loads(process.stdout)
+        return content["metadata"]
+
+    @classmethod
+    def gather_identifier(cls, source_data: dict[str, Any]) -> str:
+        return source_data["id"]["asset_id"]
+
+    @classmethod
+    def fetch(cls, source_data: dict[str, Any]) -> dict[str, Any]:
+        return source_data
+
+    @classmethod
+    def transform(cls, source_data: dict[str, Any], org_name: str) -> Iterable[SimpleStandard]:
+        yield SimpleStandard(
+            package_id=SimpleStandard.create_hashed_id(
+                cls.gather_identifier(source_data)),
+            org_name=org_name,
+            title=source_data["title"],
+            description=source_data["description"],
+            maintainer="DAFNI",
+            author=source_data["source"],
+            data_updated_at=source_data["modified_date"]
+        )

--- a/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
+++ b/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
@@ -9,6 +9,13 @@ from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Co
 
 
 class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
+    """
+    Collector for DAFNI datasets related to OpenClim. This harvester uses the DAFNI CLI to fetch datasets that match the search term "OpenClim".
+    
+    Requires following environment variables to be set for DAFNI CLI authentication to a service account:
+    - DAFNI_USERNAME
+    - DAFNI_PASSWORD
+    """
 
     @classmethod
     def gather(cls) -> list[dict[str, Any]]:
@@ -21,7 +28,13 @@ class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
             raise RuntimeError("dafni CLI not found on PATH")
 
         process = subprocess.run([dafni_path, "get", "datasets", "--search", search_term,
-                                 "-j"], capture_output=True, text=True, check=True, env=os.environ)
+                                  "-j"], capture_output=True, text=True, check=False, env=os.environ)
+
+        # Check return code manually and extract message from stdout and stderr
+        if process.returncode != 0:
+            error_msg = process.stdout + "\n" + process.stderr
+            raise RuntimeError(f"Error running dafni CLI: {error_msg}")
+
         content = json.loads(process.stdout)
 
         return content["metadata"]

--- a/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
+++ b/ckanext/datapress_harvester/harvesters2/dafniopenclim.py
@@ -2,9 +2,6 @@ import os
 import subprocess
 import shutil
 import json
-import logging
-
-logging = logging.getLogger(__name__)
 
 from typing import Any, Iterable
 
@@ -15,9 +12,7 @@ class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
 
     @classmethod
     def gather(cls) -> list[dict[str, Any]]:
-        logging.info("Gathering DAFNI datasets...")
-        logging.info("DAFNI_USERNAME: %s", os.environ["DAFNI_USERNAME"])
-        logging.info("DAFNI_PASSWORD: %s", os.environ["DAFNI_PASSWORD"])
+
         search_term = "OpenClim"
 
         # Get filtered datasets via the DAFNI cli
@@ -28,8 +23,7 @@ class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
         process = subprocess.run([dafni_path, "get", "datasets", "--search", search_term,
                                  "-j"], capture_output=True, text=True, check=True, env=os.environ)
         content = json.loads(process.stdout)
-        print(
-            f"Found {len(content['metadata'])} datasets matching search term '{search_term}'")
+
         return content["metadata"]
 
     @classmethod
@@ -52,10 +46,3 @@ class DafniCollect(Collector[dict[str, Any], dict[str, Any]]):
             author=source_data["source"],
             data_updated_at=source_data["modified_date"]
         )
-
-
-# collector = DafniCollect()
-
-# metadata = collector.gather()
-
-# print(json.dumps(metadata, indent=2))

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -268,18 +268,3 @@ class DafniOpenClimHarvester(SimpleHarvester):
             "title": "DAFNI OpenCLIM",
             "description": "Harvests OpenCLIM data from the DAFNI cli"
         }
-
-
-class TestHarvester(SimpleHarvester):
-
-    @staticmethod
-    def collector():
-        pass
-
-    @staticmethod
-    def info() -> dict[str, str]:
-        return {
-            "name": "test-harvester",
-            "title": "Test Harvester",
-            "description": "Harvester used for testing"
-        }

--- a/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
+++ b/ckanext/datapress_harvester/harvesters2/lib/harvesters.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Any, Dict
 
 from ckanext.datapress_harvester.harvesters2.lib.utils import SimpleStandard, Collector
-from ckanext.datapress_harvester.harvesters2 import fingertips, tflunified, ukpn, tflopen, laep, instantatlas
+from ckanext.datapress_harvester.harvesters2 import fingertips, tflunified, ukpn, tflopen, laep, instantatlas, dafniopenclim
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
@@ -252,4 +252,34 @@ class InstantAtlasHarvester(SimpleHarvester):
             "name": "instant-atlas",
             "title": "Instant Atlas",
             "description": "Harvests from the ESRI InstantAtlas portals"
+        }
+
+
+class DafniOpenClimHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector() -> dafniopenclim.DafniCollect:
+        return dafniopenclim.DafniCollect()
+
+    @staticmethod
+    def info() -> dict[str, str]:
+        return {
+            "name": "dafni-open-clim",
+            "title": "DAFNI OpenCLIM",
+            "description": "Harvests OpenCLIM data from the DAFNI cli"
+        }
+
+
+class TestHarvester(SimpleHarvester):
+
+    @staticmethod
+    def collector():
+        pass
+
+    @staticmethod
+    def info() -> dict[str, str]:
+        return {
+            "name": "test-harvester",
+            "title": "Test Harvester",
+            "description": "Harvester used for testing"
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 xmltodict
 python-dateutil
+dafni-cli

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         tflopen_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:TflOpenHarvester
         laep_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:LAEPHarvester
         instantatlas_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:InstantAtlasHarvester
+        dafniopenclim_harvester=ckanext.datapress_harvester.harvesters2.lib.harvesters:DafniOpenClimHarvester
     """,
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel


### PR DESCRIPTION
relates to: http://london.atlassian.net/wiki/spaces/dfl/pages/4934238210/DAFNI-+OpenCLIM

Harvester using DAFNI CLI (https://github.com/dafnifacility/cli/blob/main/docs/dafni_cli.md) to extract metadata related to OpenCLIM.

Requires the following environment variables to be set, preferably in ``dfl-monorepo ``:
```
#DAFNI service account credentials for harvesting
DAFNI_USERNAME = "username"
DAFNI_PASSWORD = "password"
```

A service account is required [here](https://keycloak.secure.dafni.rl.ac.uk/realms/Production/protocol/openid-connect/auth?client_id=dafni-main&redirect_uri=https%3A%2F%2Ffacility.secure.dafni.rl.ac.uk%2F&state=621f7bfd-6fd9-4b26-a059-207df5a187e5&response_mode=fragment&response_type=code&scope=openid&nonce=d0ed2c76-8266-4f81-85c3-a9f880292a05)
